### PR TITLE
add android stl option

### DIFF
--- a/build/android.ini
+++ b/build/android.ini
@@ -9,7 +9,8 @@ cfg_default_gcc_version=4.9
 cfg_arm_alias_folder_name="armeabi"
 cfg_armv7_alias_folder_name="armeabi-v7a"
 cfg_arm64_alias_folder_name="armeabi-v8a"
-
+#specific the STL version, currently only clang and gnu is supported
+cfg_default_build_stl="gnu"  #clang is another option
 
 #build machine & build host
 cfg_build_machine="x86_64-apple-darwin14"
@@ -30,7 +31,7 @@ cfg_armv7_toolchain_bin="${ANDROID_NDK}/toolchains/arm-linux-androideabi-${cfg_d
 #build arches and build libraries
 cfg_all_supported_arches=("arm" "armv7" "x86" "arm64")
 cfg_all_supported_libraries=("png" "zlib" "lua" "luajit" "websockets" "curl" "freetype" "jpeg"  "tiff" "webp" "chipmunk" "openssl" "gafplayer")
-cfg_default_arches_all=("arm" "armv7" "x86" "arm64")
+cfg_default_arches_all=("arm" "armv7" "x86")
 cfg_default_libraries_all=("png" "zlib" "lua" "luajit" "websockets" "curl" "freetype" "jpeg" "tiff" "webp" "chipmunk" "openssl" "gafplayer")
 
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -315,6 +315,7 @@ do
         fi
 
         export ANDROID_USE_MTHUMB=$use_mthumb
+        export ANDROID_STL_VERSION=$cfg_default_build_stl
 
         install_library_path="install-${cfg_platform_name}"
         build_library_path=$cfg_platform_name

--- a/contrib/bootstrap
+++ b/contrib/bootstrap
@@ -279,6 +279,13 @@ check_android_sdk()
             add_make_enabled "HAVE_x86"
             add_make "EXTRA_CFLAGS := -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes  -fomit-frame-pointer -fstrict-aliasing -DANDROID  -Wa,--noexecstack -Wformat "
         fi
+
+        if [ ${ANDROID_STL_VERSION} = "gnu" ];then
+            add_make_enabled "HAVE_STL_GUN"
+        else
+            add_make_enabled "HAVE_STL_CLANG"
+        fi
+        
 }
 
 check_tizen_sdk()

--- a/contrib/src/gafplayer/rules.mak
+++ b/contrib/src/gafplayer/rules.mak
@@ -30,8 +30,10 @@ ifdef HAVE_ANDROID
 CMAKE_DEFINE=ANDROID
 endif
 
+ifndef HAVE_CROSS_COMPILE
 ifdef HAVE_LINUX
 CMAKE_DEFINE=LINUX
+endif
 endif
 
 .gafplayer: gafplayer toolchain.cmake

--- a/contrib/src/main.mak
+++ b/contrib/src/main.mak
@@ -419,9 +419,18 @@ ifdef HAVE_ANDROID
 	echo "set(CMAKE_SYSTEM_NAME Linux)" >> $@
 	echo "set(CMAKE_CXX_SYSROOT_FLAG \"\")" >> $@
 	echo "set(CMAKE_C_SYSROOT_FLAG \"\")" >> $@
-	echo "include_directories($(ANDROID_NDK)/sources/android/support/include \
-		$(ANDROID_NDK)/sources/cxx-stl/llvm-libc++/libcxx/include)"  >> $@
+ifdef HAVE_STL_GUN
+	echo "include_directories($(ANDROID_NDK)/sources/cxx-stl/gnu-libstdc++/4.9/include  \
+	    $(ANDROID_NDK)/sources/cxx-stl/gnu-libstdc++/4.9/libs/$(MY_TARGET_ARCH)/include \
+            $(ANDROID_NDK)/sources/cxx-stl/gnu-libstdc++/4.9/include/backward)"  >> $@
 endif
+ifdef HAVE_STL_CLANG
+	echo "include_directories($(ANDROID_NDK)/sources/android/support/include \
+	 	$(ANDROID_NDK)/sources/cxx-stl/llvm-libc++/libcxx/include)"  >> $@
+endif
+
+endif  #end of HAVE_ANDROID
+
 ifdef HAVE_TIZEN
 	echo "set(CMAKE_SYSTEM_NAME Linux)" >> $@
 endif


### PR DESCRIPTION
1. let android only compile armeabi, armeabi-v7a and x86 on default

2. add STL option(clang and gnu_stl)  when building some c++ library. It is very important to sync the STL version of the cocos2d-x engine and the external library.

And some minor fix.