### PR TITLE
Enable ipv6 support to libcurl for v3

### DIFF
--- a/contrib/src/curl/rules.mak
+++ b/contrib/src/curl/rules.mak
@@ -30,6 +30,7 @@ endif
 	cd $< && $(HOSTVARS_PIC) ./configure $(HOSTCONF) \
 		--with-ssl=$(PREFIX) \
 		--with-zlib \
+		--enable-ipv6 \
 		--disable-ldap \
 		$(configure_option)
 # ifdef HAVE_ANDROID


### PR DESCRIPTION
According to apple's following news, App apps submitted to the App Store must support ipv6.
https://developer.apple.com/news/?id=08282015a

But, by default cocos2d-x curl library does not have ipv6 support. 
This PR will enable ipv6 support on curl.It works fine on ios and android under DNS64/NAT64 environment.
