### PR TITLE
Enable ipv6 support to libcurl for v2 branch

### DIFF
--- a/contrib/src/curl/rules.mak
+++ b/contrib/src/curl/rules.mak
@@ -27,6 +27,7 @@ endif
 		--with-ssl=$(PREFIX) \
 		--with-zlib \
 		--disable-ldap \
+		--enable-ipv6 \
 		--enable-shared=no \
 		--enable-static=yes \
 		$(configure_option)


### PR DESCRIPTION
According to apple's following news, App apps submitted to the App Store must support ipv6.
https://developer.apple.com/news/?id=08282015a

But, by default cocos2d-x curl library does not have ipv6 support. 
This PR will enable ipv6 support on curl.It works fine on ios and android under DNS64/NAT64 environment.
