### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET for openssl.

### DIFF
--- a/contrib/src/openssl/rules.mak
+++ b/contrib/src/openssl/rules.mak
@@ -90,8 +90,8 @@ ifdef HAVE_LINUX
 	cd $< && perl -i -pe "s|^CFLAG= (.*)|CFLAG= ${EXTRA_CFLAGS} ${OPTIM} |g" Makefile
 endif
 ifdef HAVE_MACOSX
-	cd $< && perl -i -pe "s|^CC= xcrun clang|CC= xcrun cc -arch ${MY_TARGET_ARCH} -mmacosx-version-min=10.7 |g" Makefile
-	cd $< && perl -i -pe "s|^CFLAG= (.*)|CFLAG= -isysroot ${MACOSX_SDK} ${OPTIM} ${OPENSSL_ARCH} |g" Makefile
+	cd $< && perl -i -pe "s|^CC= xcrun clang|CC= xcrun cc -arch ${MY_TARGET_ARCH} -mmacosx-version-min=10.7 -DMACOSX_DEPLOYMENT_TARGET=10.7 |g" Makefile
+	cd $< && perl -i -pe "s|^CFLAG= (.*)|CFLAG= -isysroot ${MACOSX_SDK} ${OPTIM} ${OPENSSL_ARCH} -mmacosx-version-min=10.7 -DMACOSX_DEPLOYMENT_TARGET=10.7 |g" Makefile
 endif
 	cd $< && $(MAKE) install
 	touch $@


### PR DESCRIPTION
When libraries like curl and zlib are built, the MACOSX_DEPLOYMENT_TARGET is passed to the compiler. However, openssl is a bit different and doesn't receive the flag. 

This PR resolves the issue and ensures `MACOSX_DEPLOYMENT_TARGET` and `macosx-version-min` are passed to the compiler.

If there is another way to accomplish the goal I'm eager to learn.
