### PR TITLE
Add Patch to fix GLFW issue #566 (PR #567)

### DIFF
--- a/contrib/src/glfw/fix-pr567.patch
+++ b/contrib/src/glfw/fix-pr567.patch
@@ -1,0 +1,90 @@
+diff --git a/src/cocoa_window_orig.m b/src/cocoa_window_PATCHED.m
+index b7486ad..d4740bd 100644
+--- a/src/cocoa_window_orig.m
++++ b/src/cocoa_window.m
+@@ -154,6 +154,29 @@ static int translateKey(unsigned int key)
+     return _glfw.ns.publicKeys[key];
+ }
+
++// Translate a GLFW keycode to a mask for its GLFW modifier flag bit
++//
++static int translateKeyToFlagMask(int key)
++{
++    switch (key)
++    {
++        case GLFW_KEY_LEFT_SHIFT:
++        case GLFW_KEY_RIGHT_SHIFT:
++            return GLFW_MOD_SHIFT;
++        case GLFW_KEY_LEFT_CONTROL:
++        case GLFW_KEY_RIGHT_CONTROL:
++            return GLFW_MOD_CONTROL;
++        case GLFW_KEY_LEFT_ALT:
++        case GLFW_KEY_RIGHT_ALT:
++            return GLFW_MOD_ALT;
++        case GLFW_KEY_LEFT_SUPER:
++        case GLFW_KEY_RIGHT_SUPER:
++            return GLFW_MOD_SUPER;
++        default:
++            return 0;
++    }
++}
++
+
+ //------------------------------------------------------------------------
+ // Delegate for window related notifications
+@@ -529,19 +552,29 @@ static int translateKey(unsigned int key)
+     const int key = translateKey([event keyCode]);
+     const int mods = translateFlags(modifierFlags);
+
+-    if (modifierFlags == window->ns.modifierFlags)
+-    {
+-        if (window->keys[key] == GLFW_PRESS)
+-            action = GLFW_RELEASE;
+-        else
+-            action = GLFW_PRESS;
+-    }
+-    else if (modifierFlags > window->ns.modifierFlags)
+-        action = GLFW_PRESS;
+-    else
+-        action = GLFW_RELEASE;
+-
+-    window->ns.modifierFlags = modifierFlags;
++	// Process flag change as a key press only if the key and flag match
++	const int flagMask = translateKeyToFlagMask(key);
++	const int modsMasked = mods & flagMask;
++	const int prevModsMasked =
++	  translateFlags(window->ns.modifierFlags) & flagMask;
++
++	if ((modsMasked & prevModsMasked) != 0)
++	{
++	  // Toggle key state if key is already held, to handle left and right
++	  // modifier keys being held simultaneously
++	  if (window->keys[key] == GLFW_PRESS)
++		  action = GLFW_RELEASE;
++	  else
++		  action = GLFW_PRESS;
++	}
++	else if (modsMasked > prevModsMasked)
++	  // The bit corresponding to the key is set in the new flags
++	  action = GLFW_PRESS;
++	else
++	  // Modifier key was released or the flag change was not for this key
++	  action = GLFW_RELEASE;
++
++	window->ns.modifierFlags = modifierFlags;
+
+     _glfwInputKey(window, key, [event keyCode], action, mods);
+ }
+@@ -906,6 +939,12 @@ static GLboolean createWindow(_GLFWwindow* window,
+
+     window->ns.view = [[GLFWContentView alloc] initWithGlfwWindow:window];
+
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++    // Initialize modifiers state with any already held modifiers
++    window->ns.modifierFlags =
++        [NSEvent modifierFlags] & NSDeviceIndependentModifierFlagsMask;
++#endif /*MAC_OS_X_VERSION_MAX_ALLOWED*/
++
+ #if defined(_GLFW_USE_RETINA)
+ #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+     if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6)

--- a/contrib/src/glfw/rules.mak
+++ b/contrib/src/glfw/rules.mak
@@ -10,6 +10,7 @@ $(TARBALLS)/glfw-$(GLFW_VERSION).tar.gz:
 
 glfw: glfw-$(GLFW_VERSION).tar.gz .sum-glfw
 	$(UNPACK)
+	$(APPLY) $(SRC)/glfw/fix-pr567.patch
 	$(MOVE)
 
 .glfw: glfw


### PR DESCRIPTION
This patches in the following GLFW pull request. In the future if GLFW merges into a version that cocos2d is going to support this patch can be removed.

The code should affect only mac builds, but note it has been tested only on Mac El Capitan 10.11.3

ref: https://github.com/glfw/glfw/pull/567
