### PR TITLE
V3 winrt update build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,17 @@ Then use command as follow to build 32-bit libs
 ./build.sh -p=platform --libs=libs --arch=i386 --mode=mode
 ```
 
-### For Windows 8.1 Universal App users
-The build script for Windows 8.1 Universal Apps in in build\build_winrt.bat. In order to run the script you will need to install Git for Windows from https://msysgit.github.io/. During the install, make sure you select the "Use Git and optional Unix tools from the Windows Command Prompt" in the "Adjusting your Path Environment" step. build_winrt.bat uses some of the binaries installed by Git for Windows. 
+### For Windows 8.1 Universal App and Windows 10 UWP App users
+The build script for Windows 8.1 Universal Apps and Windows 10 UWP Apps is in build\dobuild_winrt.bat. In order to run the script you will need to install Git for Windows from https://msysgit.github.io/. During the install, make sure you select the "Use Git and optional Unix tools from the Windows Command Prompt" in the "Adjusting your Path Environment" step. dobuild_winrt.bat uses some of the binaries installed by Git for Windows. 
 
 You will also need to install Perl http://www.activestate.com/activeperl/downloads in order to build OpenSSL.
 
-After build_winrt.bat is complete, the built libs wil be in contrib\install-winrt.
+After dobuild_winrt.bat is complete, the built libs wil be in contrib\install-winrt.
 
 
-### For Windows (Win32) and  Windows 10 Universal App users
+### For Windows (Win32)
 
-To build static libraries for Win32 and Windows 10 Universal is straightfoward, you could just setup a new static libary project with VisualStudio
+To build static libraries for Win32 is straightfoward, you could just setup a new static libary project with VisualStudio
 and import all the needed source files and header files into the project.
 
 Note: Some libraries use configure system to generate the required header files for Windows platform. If you find some 

--- a/build/build_winrt.bat
+++ b/build/build_winrt.bat
@@ -9,19 +9,45 @@ if exist %INSTALL_DIR% (
 
 mkdir %INSTALL_DIR%
 
+rem zlib and openssl must be built first!
 call:winrt_build zlib
+call:winrt_install zlib
+
+call:winrt_build openssl
+rem don't install openssl
+
 call:winrt_build angle
+call:winrt_install angle
+
 call:winrt_build chipmunk
+call:winrt_install chipmunk
+
+call:winrt_build curl
+call:winrt_install curl
+
 call:winrt_build freetype
+call:winrt_install freetype
+
 call:winrt_build ogg
+call:winrt_install ogg
+
 call:winrt_build sqlite
+call:winrt_install sqlite
+
 call:winrt_build websockets
+call:winrt_install websockets
+
 goto:eof
 
 :winrt_build  
 pushd ..\contrib\src\%~1\winrt
 echo Building %~1...
-call cmd /c "dobuild.bat"
+start /wait cmd /c "dobuild.bat"
+popd
+goto:eof
+
+:winrt_install  
+pushd ..\contrib\src\%~1\winrt
 echo Installing %~1...
 xcopy install %INSTALL_DIR% /iycqs
 popd

--- a/build/dobuild_winrt.bat
+++ b/build/dobuild_winrt.bat
@@ -1,0 +1,4 @@
+@echo off
+
+start /wait cmd /c "build_winrt.bat"
+

--- a/contrib/src/angle/winrt/build-source.bat
+++ b/contrib/src/angle/winrt/build-source.bat
@@ -1,0 +1,116 @@
+@echo off
+
+set CONFIG="release"
+if not "%1"=="" set CONFIG=%1
+
+set SHA=52be963147ea681a016ed38931685a7844429e83
+set URL=https://github.com/MSOpenTech/angle.git
+
+
+if exist temp (
+	rm -rf temp
+)
+
+if exist install (
+	rm -rf install
+)
+
+mkdir temp
+mkdir install
+
+SET PATCH=%cd%\patch\winrt.props
+
+pushd temp
+
+	if not exist %SHA%.tar.gz (
+		git clone %URL%
+	)
+
+	cd angle
+	echo Checking out commit SHA %SHA%...
+	git checkout %SHA%
+
+	call "%VS140COMNTOOLS%vsvars32.bat"
+
+	set SOLUTION=winrt\10\src\angle.sln
+	echo Building Angle Windows 10.0 UWP %CONFIG%/Win32...
+	msbuild %SOLUTION% /p:Configuration="%CONFIG%"  /p:Platform="Win32" /m
+	echo Building Angle Windows 10.0 UWP %CONFIG%/ARM...
+	msbuild %SOLUTION% /p:Configuration="%CONFIG%"  /p:Platform="ARM" /m
+
+	set SOLUTION=winrt\8.1\windows\src\angle.sln
+	echo Building Angle Windows 8.1 Store %CONFIG%/Win32...
+	msbuild %SOLUTION% /p:Configuration="%CONFIG%" /p:Platform="Win32" /m
+	echo Building Angle Windows 8.1 Store %CONFIG%/ARM...
+	msbuild %SOLUTION% /p:Configuration="%CONFIG%" /p:Platform="ARM" /m
+
+	set SOLUTION=winrt\8.1\windowsphone\src\angle.sln
+	echo Building Angle Windows 8.1 Phone %CONFIG%/Win32...
+	msbuild %SOLUTION% /p:Configuration="%CONFIG%"  /p:Platform="Win32" /m
+	echo Building Angle Windows 8.1 Phone %CONFIG%/ARM...
+	msbuild %SOLUTION% /p:Configuration="%CONFIG%"  /p:Platform="ARM" /m
+
+popd
+
+echo Installing Angle...
+
+xcopy "temp\angle\include" "install\win10-specific\angle\include\" /iycqs
+
+set INDIR=temp\angle\winrt\10\src\%CONFIG%_Win32
+set OUTDIR=install\win10-specific\angle\prebuilt\win32
+xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
+
+set INDIR=temp\angle\winrt\10\src\%CONFIG%_ARM
+set OUTDIR=install\win10-specific\angle\prebuilt\arm
+xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
+
+xcopy "temp\angle\include" "install\winrt_8.1-specific\angle\include\" /iycqs
+
+set INDIR=temp\angle\winrt\8.1\windows\src\%CONFIG%_Win32
+set OUTDIR=install\winrt_8.1-specific\angle\prebuilt\win32
+xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
+
+set INDIR=temp\angle\winrt\8.1\windows\src\%CONFIG%_ARM
+set OUTDIR=install\winrt_8.1-specific\angle\prebuilt\arm
+xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
+xcopy "temp\angle\include" "install\wp_8.1-specific\angle\include\" /iycqs
+
+set INDIR=temp\angle\winrt\8.1\windowsphone\src\%CONFIG%_Win32
+set OUTDIR=install\wp_8.1-specific\angle\prebuilt\win32
+xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
+
+set INDIR=temp\angle\winrt\8.1\windowsphone\src\%CONFIG%_ARM
+set OUTDIR=install\wp_8.1-specific\angle\prebuilt\arm
+xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
+
+echo Angle build complete.

--- a/contrib/src/angle/winrt/build.bat
+++ b/contrib/src/angle/winrt/build.bat
@@ -1,6 +1,6 @@
 @echo off
 
-set VERSION=2.1.7
+set VERSION=2.1.8
 set ANGLE_URL=http://api.nuget.org/packages/angle.windowsstore.%VERSION%.nupkg
 
 
@@ -17,12 +17,12 @@ mkdir install
 
 pushd temp
 	echo downloading ANGLE version %VERSION%
-	if not exist angle.windowsstore.2.1.7.nupkg (
+	if not exist angle.windowsstore.%VERSION%.nupkg (
 		curl -O -L %ANGLE_URL%
 	)
 	
 
-	unzip angle.windowsstore.2.1.7.nupkg -d angle
+	unzip angle.windowsstore.%VERSION%.nupkg -d angle
 popd
 
 echo Installing ANGLE...

--- a/contrib/src/angle/winrt/build.bat
+++ b/contrib/src/angle/winrt/build.bat
@@ -1,7 +1,7 @@
 @echo off
 
-set SHA=ccee5a6f7a281e325cbb9a09deab5fcc76336b26
-set URL=https://github.com/msopentech/angle/archive/%SHA%.tar.gz
+set VERSION=2.1.7
+set ANGLE_URL=http://api.nuget.org/packages/angle.windowsstore.%VERSION%.nupkg
 
 
 if exist temp (
@@ -15,99 +15,41 @@ if exist install (
 mkdir temp
 mkdir install
 
-SET PATCH=%cd%\patch\winrt.props
-
 pushd temp
+	echo downloading ANGLE version %VERSION%
+	if not exist angle.windowsstore.2.1.7.nupkg (
+		curl -O -L %ANGLE_URL%
+	)
+	
 
-if not exist %SHA%.tar.gz (
-	echo Downloading Angle commit sha %SHA%...
-	curl -O -L %URL%
-)
-
-echo Decompressing Angle commit sha %SHA%...
-tar -xzf %SHA%.tar.gz
-
-call "%VS140COMNTOOLS%vsvars32.bat"
-
-set SOLUTION=angle-%SHA%\winrt\10\build\angle.sln
-echo Building Angle Windows 10.0 UWP Release/Win32...
-msbuild %SOLUTION% /p:Configuration="Release"  /p:Platform="Win32" /m
-echo Building Angle Windows 10.0 UWP Release/ARM...
-msbuild %SOLUTION% /p:Configuration="Release"  /p:Platform="ARM" /m
-
-set SOLUTION=angle-%SHA%\winrt\8.1\windows\src\angle.sln
-echo Building Angle Windows 8.1 Store Release/Win32...
-msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="Win32" /m
-echo Building Angle Windows 8.1 Store Release/ARM...
-msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="ARM" /m
-
-set SOLUTION=angle-%SHA%\winrt\8.1\windowsphone\src\angle.sln
-echo Building Angle Windows 8.1 Phone Release/Win32...
-msbuild %SOLUTION% /p:Configuration="Release"  /p:Platform="Win32" /m
-echo Building Angle Windows 8.1 Phone Release/ARM...
-msbuild %SOLUTION% /p:Configuration="Release"  /p:Platform="ARM" /m
-
+	unzip angle.windowsstore.2.1.7.nupkg -d angle
 popd
 
-echo Installing Angle...
+echo Installing ANGLE...
 
-xcopy "temp\angle-%SHA%\include" "install\win10-specific\angle\include\" /iycqs
+set INDIR=temp\angle\
 
-set INDIR=temp\angle-%SHA%\winrt\10\build\Release_Win32
-set OUTDIR=install\win10-specific\angle\prebuilt\win32
-xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
+set OUTDIR=install\win10-specific\angle\include
+xcopy "%INDIR%\Include" "%OUTDIR%" /iycqs
+set OUTDIR=install\win10-specific\angle\prebuilt
+xcopy "%INDIR%\bin\UAP\Win32" "%OUTDIR%\win32" /iycqs
+xcopy "%INDIR%\bin\UAP\ARM" "%OUTDIR%\arm" /iycqs
 
-set INDIR=temp\angle-%SHA%\winrt\10\build\Release_ARM
-set OUTDIR=install\win10-specific\angle\prebuilt\arm
-xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
+set OUTDIR=install\winrt_8.1-specific\angle\include
+xcopy "%INDIR%\Include" "%OUTDIR%" /iycqs
+set OUTDIR=install\winrt_8.1-specific\angle\prebuilt
+xcopy "%INDIR%\bin\Windows\Win32" "%OUTDIR%\win32" /iycqs
+xcopy "%INDIR%\bin\Windows\ARM" "%OUTDIR%\arm" /iycqs
 
-xcopy "temp\angle-%SHA%\include" "install\winrt_8.1-specific\angle\include\" /iycqs
+set OUTDIR=install\wp_8.1-specific\angle\include
+xcopy "%INDIR%\Include" "%OUTDIR%" /iycqs
+set OUTDIR=install\wp_8.1-specific\angle\prebuilt
+xcopy "%INDIR%\bin\Phone\Win32" "%OUTDIR%\win32" /iycqs
+xcopy "%INDIR%\bin\Phone\ARM" "%OUTDIR%\arm" /iycqs
 
-set INDIR=temp\angle-%SHA%\winrt\8.1\windows\src\Release_Win32
-set OUTDIR=install\winrt_8.1-specific\angle\prebuilt\win32
-xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
+echo ANGLE build complete.
 
-set INDIR=temp\angle-%SHA%\winrt\8.1\windows\src\Release_ARM
-set OUTDIR=install\winrt_8.1-specific\angle\prebuilt\arm
-xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
-xcopy "temp\angle-%SHA%\include" "install\wp_8.1-specific\angle\include\" /iycqs
 
-set INDIR=temp\angle-%SHA%\winrt\8.1\windowsphone\src\Release_Win32
-set OUTDIR=install\wp_8.1-specific\angle\prebuilt\win32
-xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
 
-set INDIR=temp\angle-%SHA%\winrt\8.1\windowsphone\src\Release_ARM
-set OUTDIR=install\wp_8.1-specific\angle\prebuilt\arm
-xcopy "%INDIR%\lib\libEGL.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libEGL.pdb" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\lib\libGLESv2.lib" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.dll" "%OUTDIR%\*" /iycq
-xcopy "%INDIR%\libGLESv2.pdb" "%OUTDIR%\*" /iycq
 
-echo Angle build complete.
+

--- a/contrib/src/chipmunk/winrt/build.bat
+++ b/contrib/src/chipmunk/winrt/build.bat
@@ -17,6 +17,8 @@ mkdir install
 
 SET PATCH=%cd%\patch\winrt.patch
 
+echo Downloading Chipmunk %VERSION%...
+
 if not exist ../../../tarballs\Chipmunk-%VERSION%.tgz (
 	curl -o ../../../tarballs/Chipmunk-%VERSION%.tgz -L %URL%
 )
@@ -24,7 +26,7 @@ if not exist ../../../tarballs\Chipmunk-%VERSION%.tgz (
 
 pushd temp
 
-	echo Decompressing Chipmunk...
+	echo Decompressing Chipmunk-%VERSION%.tgz...
 	tar -xzf ../../../../tarballs/Chipmunk-%VERSION%.tgz
 
 	echo Patching Chipmunk...
@@ -110,9 +112,9 @@ pushd temp
 	msbuild win10\win32\chipmunk.sln /p:Configuration="MinSizeRel" /p:Platform="Win32" /p:ForceImportBeforeCppTargets=%PROPS% /m
 	msbuild win10\win32\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="Win32" /p:ForceImportBeforeCppTargets=%PROPS% /m
 	
-	echo Building Chipmunk Windows 10.0 Store Release/x64...
-	msbuild win10\x64\chipmunk.sln /p:Configuration="MinSizeRel" /p:Platform="x64" /p:ForceImportBeforeCppTargets=%PROPS% /m
-	msbuild win10\x64\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="x64" /p:ForceImportBeforeCppTargets=%PROPS% /m
+	rem echo Building Chipmunk Windows 10.0 Store Release/x64...
+	rem msbuild win10\x64\chipmunk.sln /p:Configuration="MinSizeRel" /p:Platform="x64" /p:ForceImportBeforeCppTargets=%PROPS% /m
+	rem msbuild win10\x64\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="x64" /p:ForceImportBeforeCppTargets=%PROPS% /m
 
 	echo Building Chipmunk Windows 10.0 Store Release/ARM...
 	msbuild win10\arm\chipmunk.sln /p:Configuration="MinSizeRel" /p:Platform="ARM" /p:ForceImportBeforeCppTargets=%PROPS% /m
@@ -142,9 +144,9 @@ set INDIR=temp\win10\win32\install
 set OUTDIR=install\chipmunk\prebuilt\win10\win32
 xcopy "%INDIR%\lib\chipmunk.lib" "%OUTDIR%\*" /iycq
 
-set INDIR=temp\win10\x64\install
-set OUTDIR=install\chipmunk\prebuilt\win10\x64
-xcopy "%INDIR%\lib\chipmunk.lib" "%OUTDIR%\*" /iycq
+rem set INDIR=temp\win10\x64\install
+rem set OUTDIR=install\chipmunk\prebuilt\win10\x64
+rem xcopy "%INDIR%\lib\chipmunk.lib" "%OUTDIR%\*" /iycq
 
 set INDIR=temp\win10\arm\install
 set OUTDIR=install\chipmunk\prebuilt\win10\arm

--- a/contrib/src/chipmunk/winrt/patch/readme.txt
+++ b/contrib/src/chipmunk/winrt/patch/readme.txt
@@ -1,0 +1,3 @@
+diff -rupN Chipmunk-6.2.2 "Chipmunk-6.2.2 - Copy" > winrt.patch
+
+Put winrt.patch in winrt/patch

--- a/contrib/src/chipmunk/winrt/patch/readme.txt
+++ b/contrib/src/chipmunk/winrt/patch/readme.txt
@@ -1,3 +1,3 @@
-diff -rupN Chipmunk-6.2.2 "Chipmunk-6.2.2 - Copy" > winrt.patch
+diff -rupN Chipmunk-7.0.1 "Chipmunk-7.0.1-1" > winrt.patch
 
 Put winrt.patch in winrt/patch

--- a/contrib/src/chipmunk/winrt/patch/winrt.patch
+++ b/contrib/src/chipmunk/winrt/patch/winrt.patch
@@ -1,6 +1,6 @@
-diff -rupN Chipmunk-7.0.1/CMakeLists.txt "Chipmunk-7.0.1 - Copy/CMakeLists.txt"
+diff -rupN Chipmunk-7.0.1/CMakeLists.txt Chipmunk-7.0.1-1/CMakeLists.txt
 --- Chipmunk-7.0.1/CMakeLists.txt	2015-07-02 09:24:47.000000000 -0700
-+++ "Chipmunk-7.0.1 - Copy/CMakeLists.txt"	2016-03-11 07:59:33.178140000 -0800
++++ Chipmunk-7.0.1-1/CMakeLists.txt	2016-04-15 06:35:29.530018300 -0700
 @@ -60,6 +60,7 @@ if(NOT MSVC)
    endif()
    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -ffast-math") # extend release-profile with fast-math
@@ -9,9 +9,25 @@ diff -rupN Chipmunk-7.0.1/CMakeLists.txt "Chipmunk-7.0.1 - Copy/CMakeLists.txt"
  endif()
  
  add_subdirectory(src)
-diff -rupN Chipmunk-7.0.1/src/chipmunk.c "Chipmunk-7.0.1 - Copy/src/chipmunk.c"
+diff -rupN Chipmunk-7.0.1/include/chipmunk/chipmunk.h Chipmunk-7.0.1-1/include/chipmunk/chipmunk.h
+--- Chipmunk-7.0.1/include/chipmunk/chipmunk.h	2015-07-02 09:24:47.000000000 -0700
++++ Chipmunk-7.0.1-1/include/chipmunk/chipmunk.h	2016-04-15 06:36:17.959673500 -0700
+@@ -28,7 +28,11 @@
+ #ifdef WIN32
+ 	// For alloca().
+ 	#include <malloc.h>
+-	#define CP_EXPORT __declspec(dllexport)
++    #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
++        #define CP_EXPORT __declspec(dllexport)
++    #else
++	    #define CP_EXPORT
++    #endif
+ #else
+ 	#include <alloca.h>
+ 	#define CP_EXPORT
+diff -rupN Chipmunk-7.0.1/src/chipmunk.c Chipmunk-7.0.1-1/src/chipmunk.c
 --- Chipmunk-7.0.1/src/chipmunk.c	2015-07-02 09:24:47.000000000 -0700
-+++ "Chipmunk-7.0.1 - Copy/src/chipmunk.c"	2016-03-11 07:58:04.364585500 -0800
++++ Chipmunk-7.0.1-1/src/chipmunk.c	2016-04-15 06:35:29.545645300 -0700
 @@ -43,7 +43,7 @@ cpMessage(const char *condition, const c
  #define STR(s) #s
  #define XSTR(s) STR(s)

--- a/contrib/src/curl/winrt/build.bat
+++ b/contrib/src/curl/winrt/build.bat
@@ -1,0 +1,313 @@
+@echo off
+
+set VERSION=7.48.0
+set URL=http://curl.haxx.se/download/curl-%VERSION%.tar.gz
+set CMAKE_ARGS=-DCURL_LDAP_WIN:BOOL="0" -DCMAKE_USE_OPENSSL:BOOL="1" -DCMAKE_USE_LIBSSH2:BOOL="0" -DENABLE_UNIX_SOCKETS:BOOL="0" -DENABLE_MANUAL:BOOL="0" -DBUILD_CURL_EXE:BOOL="0" -DBUILD_CURL_TESTS:BOOL="0" -DUSE_WIN32_LDAP:BOOL="0" -DCURL_DISABLE_TELNET:BOOL="1" -DENABLE_IPV6:BOOL="0"
+set ZLIB_DIR=%cd%\..\..\zlib\winrt\install
+set OpenSSL_DIR=%cd%\..\..\openssl\winrt\install
+SET PATCH=%cd%\patch\winrt.patch
+
+
+if exist install (
+	rm -rf install
+)
+mkdir install
+
+if exist temp (
+	rm -rf temp
+)
+mkdir temp
+
+pushd temp
+	if not exist curl-%VERSION%.tar.gz (
+		curl -O -L %URL%
+	)
+
+	echo Decompressing curl-%VERSION%.tar.gz...
+	tar -xzf curl-%VERSION%.tar.gz
+
+	pushd curl-%VERSION%
+		set SRC=%cd%
+		echo Applying winrt patch...
+		patch -p1 < %PATCH%
+	popd
+popd
+	
+:CMAKE
+pushd temp
+	echo Generating project files with CMake...
+
+	mkdir wp_8.1
+	pushd wp_8.1
+		mkdir win32
+		pushd win32
+			set INSTALL=%CD%\install
+			set ZIB_INCLUDE_DIR=-DZLIB_INCLUDE_DIR:FILEPATH="%ZLIB_DIR%\wp_8.1-specific\zlib\include"
+			set ZLIB_LIBRARY_RELEASE=-DZLIB_LIBRARY_RELEASE:FILEPATH="%ZLIB_DIR%\wp_8.1-specific\zlib\prebuilt\win32\zlib.lib"
+			set ZLIB_LIBRARY_DEBUG=-DZLIB_LIBRARY_DEBUG:FILEPATH="%ZLIB_DIR%\wp_8.1-specific\zlib\prebuilt\win32\zlib.lib"
+			
+			set OPENSSL_INCLUDE_DIR=-DOPENSSL_INCLUDE_DIR:FILEPATH="%OpenSSL_DIR%\include"
+
+			set SSL_EAY_LIBRARY_DEBUG=-DSSL_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\Win32\ssleay32.lib"
+			set SSL_EAY_DEBUG=-DSSL_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\Win32\ssleay32.lib"
+			set SSL_EAY_LIBRARY_RELEASE=-DSSL_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\Win32\ssleay32.lib"
+			set SSL_EAY_RELEASE=-DSSL_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\Win32\ssleay32.lib"
+			
+			set LIB_EAY_LIBRARY_DEBUG=-DLIB_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\Win32\libeay32.lib"
+			set LIB_EAY_DEBUG=-DLIB_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\Win32\libeay32.lib"
+			set LIB_EAY_LIBRARY_RELEASE=-DLIB_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\Win32\libeay32.lib"
+			set LIB_EAY_RELEASE=-DLIB_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\Win32\libeay32.lib"
+
+			
+			set ARGS=%CMAKE_ARGS% %ZIB_INCLUDE_DIR% %ZLIB_LIBRARY_RELEASE% %ZLIB_LIBRARY_DEBUG% %OPENSSL_INCLUDE_DIR% %SSL_EAY_LIBRARY_DEBUG% %SSL_EAY_DEBUG% %SSL_EAY_LIBRARY_RELEASE% %SSL_EAY_RELEASE% %LIB_EAY_LIBRARY_DEBUG% %LIB_EAY_DEBUG% %LIB_EAY_LIBRARY_RELEASE% %LIB_EAY_RELEASE%
+			echo %ARGS%
+			cmake -G"Visual Studio 14 2015" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
+		popd
+		
+		mkdir arm
+		pushd arm
+			set INSTALL=%CD%\install
+			set ZIB_INCLUDE_DIR=-DZLIB_INCLUDE_DIR:FILEPATH="%ZLIB_DIR%\wp_8.1-specific\zlib\include"
+			set ZLIB_LIBRARY_RELEASE=-DZLIB_LIBRARY_RELEASE:FILEPATH="%ZLIB_DIR%\wp_8.1-specific\zlib\prebuilt\arm\zlib.lib"
+			set ZLIB_LIBRARY_DEBUG=-DZLIB_LIBRARY_DEBUG:FILEPATH="%ZLIB_DIR%\wp_8.1-specific\zlib\prebuilt\arm\zlib.lib"
+			
+			set OPENSSL_INCLUDE_DIR=-DOPENSSL_INCLUDE_DIR:FILEPATH="%OpenSSL_DIR%\include"
+
+			set SSL_EAY_LIBRARY_DEBUG=-DSSL_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\arm\ssleay32.lib"
+			set SSL_EAY_DEBUG=-DSSL_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\arm\ssleay32.lib"
+			set SSL_EAY_LIBRARY_RELEASE=-DSSL_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\arm\ssleay32.lib"
+			set SSL_EAY_RELEASE=-DSSL_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\arm\ssleay32.lib"
+			
+			set LIB_EAY_LIBRARY_DEBUG=-DLIB_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\arm\libeay32.lib"
+			set LIB_EAY_DEBUG=-DLIB_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\arm\libeay32.lib"
+			set LIB_EAY_LIBRARY_RELEASE=-DLIB_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\arm\libeay32.lib"
+			set LIB_EAY_RELEASE=-DLIB_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Phone\8.1\Dll\Unicode\Release\arm\libeay32.lib"
+
+			
+			set ARGS=%CMAKE_ARGS% %ZIB_INCLUDE_DIR% %ZLIB_LIBRARY_RELEASE% %ZLIB_LIBRARY_DEBUG% %OPENSSL_INCLUDE_DIR% %SSL_EAY_LIBRARY_DEBUG% %SSL_EAY_DEBUG% %SSL_EAY_LIBRARY_RELEASE% %SSL_EAY_RELEASE% %LIB_EAY_LIBRARY_DEBUG% %LIB_EAY_DEBUG% %LIB_EAY_LIBRARY_RELEASE% %LIB_EAY_RELEASE%
+			echo %ARGS%
+			cmake -G"Visual Studio 14 2015 ARM" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
+		popd
+	popd
+	
+	mkdir winrt_8.1
+	pushd winrt_8.1
+		mkdir win32
+		pushd win32
+			set INSTALL=%CD%\install
+			set ZIB_INCLUDE_DIR=-DZLIB_INCLUDE_DIR:FILEPATH="%ZLIB_DIR%\winrt_8.1-specific\zlib\include"
+			set ZLIB_LIBRARY_RELEASE=-DZLIB_LIBRARY_RELEASE:FILEPATH="%ZLIB_DIR%\winrt_8.1-specific\zlib\prebuilt\win32\zlib.lib"
+			set ZLIB_LIBRARY_DEBUG=-DZLIB_LIBRARY_DEBUG:FILEPATH="%ZLIB_DIR%\winrt_8.1-specific\zlib\prebuilt\win32\zlib.lib"
+			
+			set OPENSSL_INCLUDE_DIR=-DOPENSSL_INCLUDE_DIR:FILEPATH="%OpenSSL_DIR%\include"
+
+			set SSL_EAY_LIBRARY_DEBUG=-DSSL_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\Win32\ssleay32.lib"
+			set SSL_EAY_DEBUG=-DSSL_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\Win32\ssleay32.lib"
+			set SSL_EAY_LIBRARY_RELEASE=-DSSL_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\Win32\ssleay32.lib"
+			set SSL_EAY_RELEASE=-DSSL_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\Win32\ssleay32.lib"
+			
+			set LIB_EAY_LIBRARY_DEBUG=-DLIB_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\Win32\libeay32.lib"
+			set LIB_EAY_DEBUG=-DLIB_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\Win32\libeay32.lib"
+			set LIB_EAY_LIBRARY_RELEASE=-DLIB_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\Win32\libeay32.lib"
+			set LIB_EAY_RELEASE=-DLIB_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\Win32\libeay32.lib"
+
+			
+			set ARGS=%CMAKE_ARGS% %ZIB_INCLUDE_DIR% %ZLIB_LIBRARY_RELEASE% %ZLIB_LIBRARY_DEBUG% %OPENSSL_INCLUDE_DIR% %SSL_EAY_LIBRARY_DEBUG% %SSL_EAY_DEBUG% %SSL_EAY_LIBRARY_RELEASE% %SSL_EAY_RELEASE% %LIB_EAY_LIBRARY_DEBUG% %LIB_EAY_DEBUG% %LIB_EAY_LIBRARY_RELEASE% %LIB_EAY_RELEASE%
+			echo %ARGS%
+			cmake -G"Visual Studio 14 2015" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
+		popd
+		
+		mkdir arm
+		pushd arm
+			set INSTALL=%CD%\install
+			set ZIB_INCLUDE_DIR=-DZLIB_INCLUDE_DIR:FILEPATH="%ZLIB_DIR%\winrt_8.1-specific\zlib\include"
+			set ZLIB_LIBRARY_RELEASE=-DZLIB_LIBRARY_RELEASE:FILEPATH="%ZLIB_DIR%\winrt_8.1-specific\zlib\prebuilt\arm\zlib.lib"
+			set ZLIB_LIBRARY_DEBUG=-DZLIB_LIBRARY_DEBUG:FILEPATH="%ZLIB_DIR%\winrt_8.1-specific\zlib\prebuilt\arm\zlib.lib"
+			
+			set OPENSSL_INCLUDE_DIR=-DOPENSSL_INCLUDE_DIR:FILEPATH="%OpenSSL_DIR%\include"
+
+			set SSL_EAY_LIBRARY_DEBUG=-DSSL_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\arm\ssleay32.lib"
+			set SSL_EAY_DEBUG=-DSSL_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\arm\ssleay32.lib"
+			set SSL_EAY_LIBRARY_RELEASE=-DSSL_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\arm\ssleay32.lib"
+			set SSL_EAY_RELEASE=-DSSL_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\arm\ssleay32.lib"
+			
+			set LIB_EAY_LIBRARY_DEBUG=-DLIB_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\arm\libeay32.lib"
+			set LIB_EAY_DEBUG=-DLIB_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\arm\libeay32.lib"
+			set LIB_EAY_LIBRARY_RELEASE=-DLIB_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\arm\libeay32.lib"
+			set LIB_EAY_RELEASE=-DLIB_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Store\8.1\Dll\Unicode\Release\arm\libeay32.lib"
+
+			
+			set ARGS=%CMAKE_ARGS% %ZIB_INCLUDE_DIR% %ZLIB_LIBRARY_RELEASE% %ZLIB_LIBRARY_DEBUG% %OPENSSL_INCLUDE_DIR% %SSL_EAY_LIBRARY_DEBUG% %SSL_EAY_DEBUG% %SSL_EAY_LIBRARY_RELEASE% %SSL_EAY_RELEASE% %LIB_EAY_LIBRARY_DEBUG% %LIB_EAY_DEBUG% %LIB_EAY_LIBRARY_RELEASE% %LIB_EAY_RELEASE%
+			echo %ARGS%
+			cmake -G"Visual Studio 14 2015 ARM" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
+		popd
+	popd
+	
+	mkdir win10
+	pushd win10
+		mkdir win32
+		pushd win32
+			set INSTALL=%CD%\install
+			set ZIB_INCLUDE_DIR=-DZLIB_INCLUDE_DIR:FILEPATH="%ZLIB_DIR%\win10-specific\zlib\include"
+			set ZLIB_LIBRARY_RELEASE=-DZLIB_LIBRARY_RELEASE:FILEPATH="%ZLIB_DIR%\win10-specific\zlib\prebuilt\win32\zlib.lib"
+			set ZLIB_LIBRARY_DEBUG=-DZLIB_LIBRARY_DEBUG:FILEPATH="%ZLIB_DIR%\win10-specific\zlib\prebuilt\win32\zlib.lib"
+			
+			set OPENSSL_INCLUDE_DIR=-DOPENSSL_INCLUDE_DIR:FILEPATH="%OpenSSL_DIR%\include"
+
+			set SSL_EAY_LIBRARY_DEBUG=-DSSL_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\Win32\ssleay32.lib"
+			set SSL_EAY_DEBUG=-DSSL_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\Win32\ssleay32.lib"
+			set SSL_EAY_LIBRARY_RELEASE=-DSSL_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\Win32\ssleay32.lib"
+			set SSL_EAY_RELEASE=-DSSL_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\Win32\ssleay32.lib"
+			
+			set LIB_EAY_LIBRARY_DEBUG=-DLIB_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\Win32\libeay32.lib"
+			set LIB_EAY_DEBUG=-DLIB_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\Win32\libeay32.lib"
+			set LIB_EAY_LIBRARY_RELEASE=-DLIB_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\Win32\libeay32.lib"
+			set LIB_EAY_RELEASE=-DLIB_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\Win32\libeay32.lib"
+
+			
+			set ARGS=%CMAKE_ARGS% %ZIB_INCLUDE_DIR% %ZLIB_LIBRARY_RELEASE% %ZLIB_LIBRARY_DEBUG% %OPENSSL_INCLUDE_DIR% %SSL_EAY_LIBRARY_DEBUG% %SSL_EAY_DEBUG% %SSL_EAY_LIBRARY_RELEASE% %SSL_EAY_RELEASE% %LIB_EAY_LIBRARY_DEBUG% %LIB_EAY_DEBUG% %LIB_EAY_LIBRARY_RELEASE% %LIB_EAY_RELEASE%
+			echo %ARGS%
+			cmake -G"Visual Studio 14 2015" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
+		popd
+		
+		mkdir arm
+		pushd arm
+			set INSTALL=%CD%\install
+			set ZIB_INCLUDE_DIR=-DZLIB_INCLUDE_DIR:FILEPATH="%ZLIB_DIR%\win10-specific\zlib\include"
+			set ZLIB_LIBRARY_RELEASE=-DZLIB_LIBRARY_RELEASE:FILEPATH="%ZLIB_DIR%\win10-specific\zlib\prebuilt\arm\zlib.lib"
+			set ZLIB_LIBRARY_DEBUG=-DZLIB_LIBRARY_DEBUG:FILEPATH="%ZLIB_DIR%\win10-specific\zlib\prebuilt\arm\zlib.lib"
+			
+			set OPENSSL_INCLUDE_DIR=-DOPENSSL_INCLUDE_DIR:FILEPATH="%OpenSSL_DIR%\include"
+
+			set SSL_EAY_LIBRARY_DEBUG=-DSSL_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\arm\ssleay32.lib"
+			set SSL_EAY_DEBUG=-DSSL_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\arm\ssleay32.lib"
+			set SSL_EAY_LIBRARY_RELEASE=-DSSL_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\arm\ssleay32.lib"
+			set SSL_EAY_RELEASE=-DSSL_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\arm\ssleay32.lib"
+			
+			set LIB_EAY_LIBRARY_DEBUG=-DLIB_EAY_LIBRARY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\arm\libeay32.lib"
+			set LIB_EAY_DEBUG=-DLIB_EAY_DEBUG:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\arm\libeay32.lib"
+			set LIB_EAY_LIBRARY_RELEASE=-DLIB_EAY_LIBRARY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\arm\libeay32.lib"
+			set LIB_EAY_RELEASE=-DLIB_EAY_RELEASE:FILEPATH="%OpenSSL_DIR%\lib\Universal\10.0\Dll\Unicode\Release\arm\libeay32.lib"
+
+			
+			set ARGS=%CMAKE_ARGS% %ZIB_INCLUDE_DIR% %ZLIB_LIBRARY_RELEASE% %ZLIB_LIBRARY_DEBUG% %OPENSSL_INCLUDE_DIR% %SSL_EAY_LIBRARY_DEBUG% %SSL_EAY_DEBUG% %SSL_EAY_LIBRARY_RELEASE% %SSL_EAY_RELEASE% %LIB_EAY_LIBRARY_DEBUG% %LIB_EAY_DEBUG% %LIB_EAY_LIBRARY_RELEASE% %LIB_EAY_RELEASE%
+			echo %ARGS%
+			cmake -G"Visual Studio 14 2015 ARM" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
+		popd
+		
+	popd
+	
+	call "%VS140COMNTOOLS%vsvars32.bat"
+
+	pushd wp_8.1\win32\
+		echo Building curl Windows Phone 8.1 MinSizeRel/Win32...
+		msbuild CURL.sln /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+		msbuild Install.vcxproj /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+	popd
+
+	pushd wp_8.1\arm\
+		echo Building curl Windows Phone 8.1 MinSizeRel/Win32...
+		msbuild CURL.sln /p:Configuration="MinSizeRel" /p:Platform="arm" /m
+		msbuild Install.vcxproj /p:Configuration="MinSizeRel" /p:Platform="arm" /m
+	popd
+	
+	pushd winrt_8.1\win32\
+		echo Building curl Windows Store 8.1 MinSizeRel/Win32...
+		msbuild CURL.sln /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+		msbuild Install.vcxproj /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+	popd
+
+	pushd winrt_8.1\arm\
+		echo Building curl Windows Store 8.1 MinSizeRel/Win32...
+		msbuild CURL.sln /p:Configuration="MinSizeRel" /p:Platform="arm" /m
+		msbuild Install.vcxproj /p:Configuration="MinSizeRel" /p:Platform="arm" /m
+	popd
+	
+	pushd win10\win32\
+		echo Building curl Windows 10.0 MinSizeRel/Win32...
+		msbuild CURL.sln /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+		msbuild Install.vcxproj /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+	popd
+
+	pushd win10\arm\
+		echo Building curl Windows 10.0 MinSizeRel/Win32...
+		msbuild CURL.sln /p:Configuration="MinSizeRel" /p:Platform="arm" /m
+		msbuild Install.vcxproj /p:Configuration="MinSizeRel" /p:Platform="arm" /m
+	popd
+popd
+
+:INSTALL
+echo Installing curl...
+
+rem install Win10 binary files
+set INDIR="%OpenSSL_DIR%\bin\Universal\10.0\Dll\Unicode\Release\Win32"
+set OUTDIR=install\curl\prebuilt\win10\win32
+xcopy "%INDIR%\libeay32.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\ssleay32.dll" "%OUTDIR%\*" /iycq
+
+set INDIR="temp\win10\win32\install\"
+xcopy "%INDIR%\bin\libcurl.dll" "%OUTDIR%\*" /iycqs
+xcopy "%INDIR%\lib\libcurl_imp.lib" "%OUTDIR%\*" /iycqs
+mv "%OUTDIR%\libcurl_imp.lib" "%OUTDIR%\libcurl.lib"
+
+set INDIR="%OpenSSL_DIR%\bin\Universal\10.0\Dll\Unicode\Release\arm"
+set OUTDIR=install\curl\prebuilt\win10\arm
+xcopy "%INDIR%\libeay32.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\ssleay32.dll" "%OUTDIR%\*" /iycq
+
+set INDIR="temp\win10\arm\install\"
+xcopy "%INDIR%\bin\libcurl.dll" "%OUTDIR%\*" /iycqs
+xcopy "%INDIR%\lib\libcurl_imp.lib" "%OUTDIR%\*" /iycqs
+mv "%OUTDIR%\libcurl_imp.lib" "%OUTDIR%\libcurl.lib"
+
+rem install wp_8.1 binary files
+set INDIR="%OpenSSL_DIR%\bin\Phone\8.1\Dll\Unicode\Release\Win32"
+set OUTDIR=install\curl\prebuilt\wp_8.1\win32
+xcopy "%INDIR%\libeay32.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\ssleay32.dll" "%OUTDIR%\*" /iycq
+
+set INDIR="temp\wp_8.1\win32\install\"
+xcopy "%INDIR%\bin\libcurl.dll" "%OUTDIR%\*" /iycqs
+xcopy "%INDIR%\lib\libcurl_imp.lib" "%OUTDIR%\*" /iycqs
+mv "%OUTDIR%\libcurl_imp.lib" "%OUTDIR%\libcurl.lib"
+
+set INDIR="%OpenSSL_DIR%\bin\Phone\8.1\Dll\Unicode\Release\arm"
+set OUTDIR=install\curl\prebuilt\wp_8.1\arm
+xcopy "%INDIR%\libeay32.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\ssleay32.dll" "%OUTDIR%\*" /iycq
+
+set INDIR="temp\wp_8.1\arm\install\"
+xcopy "%INDIR%\bin\libcurl.dll" "%OUTDIR%\*" /iycqs
+xcopy "%INDIR%\lib\libcurl_imp.lib" "%OUTDIR%\*" /iycqs
+mv "%OUTDIR%\libcurl_imp.lib" "%OUTDIR%\libcurl.lib"
+
+rem install winrt_8.1 binary files
+set INDIR="%OpenSSL_DIR%\bin\Store\8.1\Dll\Unicode\Release\Win32"
+set OUTDIR=install\curl\prebuilt\winrt_8.1\win32
+xcopy "%INDIR%\libeay32.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\ssleay32.dll" "%OUTDIR%\*" /iycq
+
+set INDIR="temp\winrt_8.1\win32\install\"
+xcopy "%INDIR%\bin\libcurl.dll" "%OUTDIR%\*" /iycqs
+xcopy "%INDIR%\lib\libcurl_imp.lib" "%OUTDIR%\*" /iycqs
+mv "%OUTDIR%\libcurl_imp.lib" "%OUTDIR%\libcurl.lib"
+
+set INDIR="%OpenSSL_DIR%\bin\Store\8.1\Dll\Unicode\Release\arm"
+set OUTDIR=install\curl\prebuilt\winrt_8.1\arm
+xcopy "%INDIR%\libeay32.dll" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\ssleay32.dll" "%OUTDIR%\*" /iycq
+
+set INDIR="temp\winrt_8.1\arm\install\"
+xcopy "%INDIR%\bin\libcurl.dll" "%OUTDIR%\*" /iycqs
+xcopy "%INDIR%\lib\libcurl_imp.lib" "%OUTDIR%\*" /iycqs
+mv "%OUTDIR%\libcurl_imp.lib" "%OUTDIR%\libcurl.lib"
+
+rem install include files
+xcopy "temp\win10\win32\install\include" "install\curl\include\win10" /iycqs
+xcopy "temp\wp_8.1\win32\install\include" "install\curl\include\wp_8.1" /iycqs
+xcopy "temp\winrt_8.1\win32\install\include" "install\curl\include\winrt_8.1" /iycqs
+
+echo curl build complete.
+
+
+

--- a/contrib/src/curl/winrt/dobuild.bat
+++ b/contrib/src/curl/winrt/dobuild.bat
@@ -1,0 +1,4 @@
+@echo off
+
+start /wait cmd /c "build.bat"
+

--- a/contrib/src/curl/winrt/patch/readme.txt
+++ b/contrib/src/curl/winrt/patch/readme.txt
@@ -1,0 +1,3 @@
+diff -rupN curl-7.48.0 curl-7.48.0-1 > winrt.patch
+
+

--- a/contrib/src/curl/winrt/patch/winrt.patch
+++ b/contrib/src/curl/winrt/patch/winrt.patch
@@ -1,0 +1,139 @@
+diff -rupN curl-7.48.0/CMakeLists.txt curl-7.48.0-1/CMakeLists.txt
+--- curl-7.48.0/CMakeLists.txt	2016-03-22 00:15:38.000000000 -0700
++++ curl-7.48.0-1/CMakeLists.txt	2016-04-12 14:12:28.724654200 -0700
+@@ -289,7 +289,14 @@ check_function_exists(gethostname HAVE_G
+ set(OPENSSL_DEFAULT ON)
+ if(WIN32)
+   set(OPENSSL_DEFAULT OFF)
+-  check_library_exists_concat("ws2_32" getch        HAVE_LIBWS2_32)
++  # Assume ws2_32 lib exists in Windows 8.1, Windows Phone 8.1
++  if((CMAKE_SYSTEM_VERSION STREQUAL "8.1") AND ((CMAKE_SYSTEM_NAME STREQUAL "WindowsStore") OR (CMAKE_SYSTEM_NAME STREQUAL "WindowsPhone")))
++    set(HAVE_LIBWS2_32 1)
++    list(APPEND CURL_LIBS ws2_32)
++  else()
++    check_library_exists_concat("ws2_32" getch        HAVE_LIBWS2_32)
++  endif()
++
+   check_library_exists_concat("winmm"  getch        HAVE_LIBWINMM)
+ endif()
+ 
+@@ -1012,8 +1019,15 @@ include(CMake/OtherTests.cmake)
+ 
+ add_definitions(-DHAVE_CONFIG_H)
+ 
+-# For windows, do not allow the compiler to use default target (Vista).
+-if(WIN32)
++if((CMAKE_SYSTEM_NAME STREQUAL "WindowsStore") OR (CMAKE_SYSTEM_NAME STREQUAL "WindowsPhone"))
++	add_definitions(-DHAVE_STRUCT_POLLFD -D_WINSOCK_DEPRECATED_NO_WARNINGS)
++	# Set correct winnt version
++	if(CMAKE_SYSTEM_VERSION STREQUAL "10.0")
++		add_definitions(-D_WIN32_WINNT=0x0A00)
++	elseif(CMAKE_SYSTEM_VERSION STREQUAL "8.1")
++		add_definitions(-D_WIN32_WINNT=0x0603)
++	endif()
++elseif(WIN32)
+   add_definitions(-D_WIN32_WINNT=0x0501)
+ endif(WIN32)
+ 
+diff -rupN curl-7.48.0/lib/config-win32.h curl-7.48.0-1/lib/config-win32.h
+--- curl-7.48.0/lib/config-win32.h	2016-03-22 00:15:38.000000000 -0700
++++ curl-7.48.0-1/lib/config-win32.h	2016-04-12 09:16:08.077747400 -0700
+@@ -516,21 +516,21 @@
+    /* The minimum build target for VS2012 is Vista unless Update 1 is installed
+       and the v110_xp toolset is choosen. */
+ #  if defined(_USING_V110_SDK71_)
+-#    define VS2012_MIN_TARGET 0x0501
++#    define VS2012_MIN_TARGET 0x0A00
+ #  else
+-#    define VS2012_MIN_TARGET 0x0600
++#    define VS2012_MIN_TARGET 0x0A00
+ #  endif
+ 
+    /* VS2008 default build target is Windows Vista. We override default target
+       to be Windows XP. */
+-#  define VS2008_DEF_TARGET 0x0501
++#  define VS2008_DEF_TARGET 0x0A00
+ 
+    /* VS2012 default build target is Windows Vista unless Update 1 is installed
+       and the v110_xp toolset is choosen. */
+ #  if defined(_USING_V110_SDK71_)
+-#    define VS2012_DEF_TARGET 0x0501
++#    define VS2012_DEF_TARGET 0x0A00
+ #  else
+-#    define VS2012_DEF_TARGET 0x0600
++#    define VS2012_DEF_TARGET 0x0A00
+ #  endif
+ #endif
+ 
+@@ -584,7 +584,7 @@ Vista
+ #    define HAVE_GETADDRINFO            1
+ #    define HAVE_GETADDRINFO_THREADSAFE 1
+ #    define HAVE_GETNAMEINFO            1
+-#  elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0501)
++#  elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0A00)
+ #    define HAVE_FREEADDRINFO           1
+ #    define HAVE_GETADDRINFO            1
+ #    define HAVE_GETADDRINFO_THREADSAFE 1
+diff -rupN curl-7.48.0/lib/connect.c curl-7.48.0-1/lib/connect.c
+--- curl-7.48.0/lib/connect.c	2016-03-22 00:15:38.000000000 -0700
++++ curl-7.48.0-1/lib/connect.c	2016-04-12 09:16:08.082056200 -0700
+@@ -953,6 +953,9 @@ void Curl_sndbufset(curl_socket_t sockfd
+       if(osver.dwMajorVersion >= majorVersion)
+         detectOsState = DETECT_OS_VISTA_OR_LATER;
+     }
++#elif defined(_WIN32_WINNT) && defined(_WIN32_WINNT_WINBLUE) && (_WIN32_WINNT >= _WIN32_WINNT_WINBLUE) && defined(WINAPI_FAMILY) && \
++	((WINAPI_FAMILY == WINAPI_FAMILY_APP) || (WINAPI_FAMILY == WINAPI_FAMILY_PC_APP) || (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP))
++	// Do nothing since VerSetConditionMask & VerifyVersionInfo API are not supported in Windows Apps environment.
+ #else
+     ULONGLONG cm;
+     OSVERSIONINFOEX osver;
+diff -rupN curl-7.48.0/lib/getenv.c curl-7.48.0-1/lib/getenv.c
+--- curl-7.48.0/lib/getenv.c	2016-03-22 00:15:38.000000000 -0700
++++ curl-7.48.0-1/lib/getenv.c	2016-04-12 09:16:08.085264200 -0700
+@@ -30,8 +30,10 @@
+ static
+ char *GetEnv(const char *variable)
+ {
+-#ifdef _WIN32_WCE
+-  return NULL;
++#if defined _WIN32_WCE || \
++    (defined(_WIN32_WINNT) && defined(_WIN32_WINNT_WINBLUE) && (_WIN32_WINNT >= _WIN32_WINNT_WINBLUE) && \
++    defined(WINAPI_FAMILY) && ((WINAPI_FAMILY == WINAPI_FAMILY_APP) || (WINAPI_FAMILY == WINAPI_FAMILY_PC_APP) || (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)))
++   return NULL;
+ #else
+ #ifdef WIN32
+   char env[MAX_PATH]; /* MAX_PATH is from windef.h */
+diff -rupN curl-7.48.0/lib/smb.c curl-7.48.0-1/lib/smb.c
+--- curl-7.48.0/lib/smb.c	2016-03-22 00:15:38.000000000 -0700
++++ curl-7.48.0-1/lib/smb.c	2016-04-12 09:16:08.088731000 -0700
+@@ -354,7 +354,15 @@ static void smb_format_message(struct co
+   h->flags2 = smb_swap16(SMB_FLAGS2_IS_LONG_NAME | SMB_FLAGS2_KNOWS_LONG_NAME);
+   h->uid = smb_swap16(smbc->uid);
+   h->tid = smb_swap16(req->tid);
+-  pid = getpid();
++
++#if defined(_WIN32_WINNT) && defined(_WIN32_WINNT_WINBLUE) && (_WIN32_WINNT >= _WIN32_WINNT_WINBLUE) && defined(WINAPI_FAMILY) && \
++	((WINAPI_FAMILY == WINAPI_FAMILY_APP) || (WINAPI_FAMILY == WINAPI_FAMILY_PC_APP) || (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP))
++	// Use Windows specific API when building for Windows Apps as getpid() is not a supported API
++	pid = GetCurrentProcessId();
++#else
++	pid = getpid();
++#endif
++
+   h->pid_high = smb_swap16((unsigned short)(pid >> 16));
+   h->pid = smb_swap16((unsigned short) pid);
+ }
+diff -rupN curl-7.48.0/lib/strerror.c curl-7.48.0-1/lib/strerror.c
+--- curl-7.48.0/lib/strerror.c	2016-03-22 00:15:38.000000000 -0700
++++ curl-7.48.0-1/lib/strerror.c	2016-04-12 09:16:08.092766000 -0700
+@@ -638,7 +638,9 @@ const char *Curl_strerror(struct connect
+ 
+ #ifdef USE_WINSOCK
+ 
+-#ifdef _WIN32_WCE
++#if defined _WIN32_WCE || \
++    (defined(_WIN32_WINNT) && defined(_WIN32_WINNT_WINBLUE) && (_WIN32_WINNT >= _WIN32_WINNT_WINBLUE) && \
++    defined(WINAPI_FAMILY) && ((WINAPI_FAMILY == WINAPI_FAMILY_APP) || (WINAPI_FAMILY == WINAPI_FAMILY_PC_APP) || (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)))
+   {
+     wchar_t wbuf[256];
+     wbuf[0] = L'\0';

--- a/contrib/src/freetype/winrt/build.bat
+++ b/contrib/src/freetype/winrt/build.bat
@@ -21,10 +21,12 @@ SET PATCH=%cd%\patch\winrt.props
 pushd temp
 
 	if not exist freetype-%VERSION%.tar.gz (
-		curl -O -L %URL%
+		echo Downloading freetype-%VERSION%.tar.gz
+		curl -O -L %URL% 
 	)
 
-	tar -xzvf freetype-%VERSION%.tar.gz
+	echo Decompressing freetype-%VERSION%.tar.gz
+	tar -xzf freetype-%VERSION%.tar.gz
 
 	pushd freetype-%VERSION%
 		set SRC=%cd%
@@ -37,12 +39,12 @@ pushd temp
 		mkdir win32
 		pushd win32
 			set INSTALL=%CD%\install
-			cmake -G"Visual Studio 12 2013" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS%  %SRC%
+			cmake -G"Visual Studio 14 2015" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS%  %SRC%
 		popd
 		mkdir arm
 		pushd arm
 			set INSTALL=%CD%\install
-			cmake -G"Visual Studio 12 2013 ARM" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
+			cmake -G"Visual Studio 14 2015 ARM" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
 		popd
 	popd
 	
@@ -51,16 +53,30 @@ pushd temp
 		mkdir win32
 		pushd win32
 			set INSTALL=%CD%\install
-			cmake -G"Visual Studio 12 2013" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS%  %SRC%
+			cmake -G"Visual Studio 14 2015" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS%  %SRC%
 		popd
 		mkdir arm
 		pushd arm
 			set INSTALL=%CD%\install
-			cmake -G"Visual Studio 12 2013 ARM" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
+			cmake -G"Visual Studio 14 2015 ARM" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
+		popd
+	popd
+	
+	mkdir win10
+	pushd win10 
+		mkdir win32
+		pushd win32
+			set INSTALL=%CD%\install
+			cmake -G"Visual Studio 14 2015" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS%  %SRC%
+		popd
+		mkdir arm
+		pushd arm
+			set INSTALL=%CD%\install
+			cmake -G"Visual Studio 14 2015 ARM" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %ARGS% %SRC%
 		popd
 	popd
 		
-	call "%VS120COMNTOOLS%vsvars32.bat"
+	call "%VS140COMNTOOLS%vsvars32.bat"
 
 	echo Building freetype Windows 8.1 Phone Release/Win32...
 	msbuild wp_8.1\win32\freetype.sln /p:Configuration="MinSizeRel" /p:Platform="Win32" /p:ForceImportBeforeCppTargets=%PATCH% /m
@@ -77,6 +93,14 @@ pushd temp
 	echo Building freetype Windows 8.1 Store Release/ARM...
 	msbuild ws_8.1\arm\freetype.sln /p:Configuration="MinSizeRel" /p:Platform="ARM" /p:ForceImportBeforeCppTargets=%PATCH% /m
 	msbuild ws_8.1\arm\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="ARM" /p:ForceImportBeforeCppTargets=%PATCH% /m
+	
+	echo Building freetype Windows 10.0 Store Release/Win32...
+	msbuild win10\win32\freetype.sln /p:Configuration="MinSizeRel" /p:Platform="Win32" /p:ForceImportBeforeCppTargets=%PATCH% /m
+	msbuild win10\win32\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="Win32" /p:ForceImportBeforeCppTargets=%PATCH% /m
+
+	echo Building freetype Windows 10.0 Store Release/ARM...
+	msbuild win10\arm\freetype.sln /p:Configuration="MinSizeRel" /p:Platform="ARM" /p:ForceImportBeforeCppTargets=%PATCH% /m
+	msbuild win10\arm\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="ARM" /p:ForceImportBeforeCppTargets=%PATCH% /m
 popd
 
 echo Installing freetype...
@@ -97,6 +121,15 @@ xcopy "%INDIR%\lib\freetype.lib" "%OUTDIR%\*" /iycq
 
 set INDIR=temp\ws_8.1\arm\install
 set OUTDIR=install\freetype2\prebuilt\winrt_8.1\arm
+xcopy "%INDIR%\lib\freetype.lib" "%OUTDIR%\*" /iycq
+
+set INDIR=temp\win10\win32\install
+set OUTDIR=install\freetype2\prebuilt\win10\win32
+xcopy "%INDIR%\include" "install\freetype2\include\win10" /iycqs
+xcopy "%INDIR%\lib\freetype.lib" "%OUTDIR%\*" /iycq
+
+set INDIR=temp\win10\arm\install
+set OUTDIR=install\freetype2\prebuilt\win10\arm
 xcopy "%INDIR%\lib\freetype.lib" "%OUTDIR%\*" /iycq
 	
 echo freetype build complete.

--- a/contrib/src/jpeg/winrt/README.txt
+++ b/contrib/src/jpeg/winrt/README.txt
@@ -1,0 +1,1 @@
+There is no need to build jpeg for the winrt platforms (Win10 UWP and Windows 8.1 Universal). The winrt platforms use WIC to load jpeg files.

--- a/contrib/src/ogg/winrt/build.bat
+++ b/contrib/src/ogg/winrt/build.bat
@@ -28,8 +28,10 @@ if not exist %VORBIS.TAR.GZ% (
 	curl -O -L %VORBIS_URL%
 )
 
-tar -xzvf %OGG.TAR.GZ%
-tar -xzvf %VORBIS.TAR.GZ%
+echo Decompressing %OGG.TAR.GZ%
+tar -xzf %OGG.TAR.GZ%
+echo Decompressing %VORBIS.TAR.GZ%
+tar -xzf %VORBIS.TAR.GZ%
 
 mv libogg-%OGG_VERSION% libogg
 mv libvorbis-%VORBIS_VERSION% libvorbis
@@ -38,12 +40,15 @@ echo Patching libogg and libvorbis...
 xcopy ..\patch\libogg\win32 libogg\win32 /iycqs
 xcopy ..\patch\libvorbis\win32 libvorbis\win32 /iycqs
 
-call "%VS120COMNTOOLS%vsvars32.bat"
+call "%VS140COMNTOOLS%vsvars32.bat"
 
 set SOLUTION=libogg\win32\VS2013\libogg-win8.1-universal.sln
 
 echo Building Ogg Windows 8.1 Release/Win32...
 msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="Win32" /m
+
+rem echo Building Ogg Windows 8.1 Release/x64...
+rem msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="x64" /m
 
 echo Building Ogg Windows 8.1 Release/ARM...
 msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="ARM" /m
@@ -53,7 +58,32 @@ set SOLUTION=libvorbis\win32\VS2013\libvorbis-win8.1-universal.sln
 echo Building Ogg Windows 8.1 Release/Win32...
 msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="Win32" /m
 
+rem echo Building Ogg Windows 8.1 Release/x64...
+rem msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="x64" /m
+
 echo Building Ogg Windows 8.1 Release/ARM...
+msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="ARM" /m
+
+set SOLUTION=libogg\win32\VS2015\libogg-win10-universal.sln
+
+echo Building Ogg Windows 10.0 Release/x86...
+msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="x86" /m
+
+rem echo Building Ogg Windows 10.0 Release/x64...
+rem msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="x64" /m
+
+echo Building Ogg Windows 10.0 Release/ARM...
+msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="ARM" /m
+
+set SOLUTION=libvorbis\win32\VS2015\libvorbis-win10-universal.sln
+
+echo Building Ogg Windows 10.0 Release/x86...
+msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="x86" /m
+
+rem echo Building Ogg Windows 10.0 Release/x64...
+rem msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="x64" /m
+
+echo Building Ogg Windows 10.0 Release/ARM...
 msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="ARM" /m
 
 popd
@@ -65,11 +95,15 @@ xcopy "temp\libogg\include\ogg" "install\winrt_8.1-specific\OggDecoder\include\o
 xcopy "temp\libvorbis\include\vorbis" "install\winrt_8.1-specific\OggDecoder\include\vorbis" /iycqs
 xcopy "temp\libogg\include\ogg" "install\wp_8.1-specific\OggDecoder\include\ogg" /iycqs
 xcopy "temp\libvorbis\include\vorbis" "install\wp_8.1-specific\OggDecoder\include\vorbis" /iycqs
+xcopy "temp\libogg\include\ogg" "install\win10-specific\OggDecoder\include\ogg" /iycqs
+xcopy "temp\libvorbis\include\vorbis" "install\win10-specific\OggDecoder\include\vorbis" /iycqs
 
 rem copy libs and dlls
-call:CopyOggFiles Windows win32 winrt_8.1
-call:CopyOggFiles Windows arm winrt_8.1
-call:CopyOggFiles WindowsPhone win32 wp_8.1
+call:CopyOggWin10Files win32
+call:CopyOggWin10Files arm
+call:CopyOggFiles Windows win32 winrt_8.1 
+call:CopyOggFiles Windows arm winrt_8.1 
+call:CopyOggFiles WindowsPhone win32 wp_8.1 
 call:CopyOggFiles WindowsPhone arm wp_8.1
 
 echo Ogg build complete.
@@ -97,4 +131,28 @@ echo INDIR=%INDIR%
 xcopy "%INDIR%\libvorbisfile.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\libvorbisfile.dll" "%OUTDIR%\*" /iycq
 goto:eof
+
+:CopyOggWin10Files   
+set INDIR=temp\libogg\win32\VS2015\%~1\Release\libogg-win10-universal
+set OUTDIR=install\win10-specific\OggDecoder\prebuilt\%~1
+
+echo INDIR=%INDIR%
+echo OUTDIR=%OUTDIR%
+xcopy "%INDIR%\libogg.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libogg.dll" "%OUTDIR%\*" /iycq
+
+set INDIR=temp\libvorbis\win32\VS2015\%~1\Release\libvorbis-win10-universal
+echo INDIR=%INDIR%
+
+xcopy "%INDIR%\libvorbis.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libvorbis.dll" "%OUTDIR%\*" /iycq
+
+set INDIR=temp\libvorbis\win32\VS2015\%~1\Release\libvorbisfile-win10-universal
+echo INDIR=%INDIR%
+
+xcopy "%INDIR%\libvorbisfile.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\libvorbisfile.dll" "%OUTDIR%\*" /iycq
+
+goto:eof
+
 

--- a/contrib/src/ogg/winrt/patch/libogg/win32/VS2015/libogg-win10-universal/libogg-win10-universal.vcxproj
+++ b/contrib/src/ogg/winrt/patch/libogg/win32/VS2015/libogg-win10-universal/libogg-win10-universal.vcxproj
@@ -38,6 +38,8 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <TargetPlatformVersion>10.0.10069.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10069.0</TargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -102,11 +104,13 @@
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
     <TargetName>libogg</TargetName>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
     <TargetName>libogg</TargetName>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <GenerateManifest>false</GenerateManifest>

--- a/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2013/libvorbis-win8.1-universal/libvorbis.Windows/libvorbis.Windows.vcxproj
+++ b/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2013/libvorbis-win8.1-universal/libvorbis.Windows/libvorbis.Windows.vcxproj
@@ -136,7 +136,7 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\..\vorbis.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>..\..\..\..\..\libogg\win32\VS2013\$(Platform)\$(Configuration)\libogg.Windows;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\..\libogg\win32\VS2013\$(Platform)\$(Configuration)\libogg.Windows;</AdditionalLibraryDirectories>
       <AdditionalDependencies>libogg.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -202,12 +202,16 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <DisableSpecificWarnings>4244;4305;4101;</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\..\..\..\libogg\include;%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>LIBVORBIS_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\..\vorbis.def</ModuleDefinitionFile>
+      <AdditionalLibraryDirectories>..\..\..\..\..\libogg\win32\VS2013\$(Platform)\$(Configuration)\libogg.Windows;</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libogg.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -217,6 +221,8 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <DisableSpecificWarnings>4244;4305;4101;</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\..\..\..\libogg\include;%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>LIBVORBIS_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -224,6 +230,8 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\..\vorbis.def</ModuleDefinitionFile>
       <LinkTimeCodeGeneration />
+      <AdditionalLibraryDirectories>..\..\..\..\..\libogg\win32\VS2013\$(Platform)\$(Configuration)\libogg.Windows;</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libogg.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2013/libvorbisfile-win8.1-universal/libvorbisfile.Windows/libvorbisfile.Windows.vcxproj
+++ b/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2013/libvorbisfile-win8.1-universal/libvorbisfile.Windows/libvorbisfile.Windows.vcxproj
@@ -136,7 +136,7 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\..\vorbisfile.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>..\..\$(Platform)\$(Configuration)\libvorbis.Windows;..\..\..\..\..\libogg\win32\VS2013\$(Platform)\$(Configuration)\libogg.Windows;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\$(Platform)\$(Configuration)\libvorbis.Windows;..\..\..\..\..\libogg\win32\VS2013\$(Platform)\$(Configuration)\libogg.Windows;</AdditionalLibraryDirectories>
       <AdditionalDependencies>libogg.lib;libvorbis.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -202,12 +202,16 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <DisableSpecificWarnings>4244;4305;4101;</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\..\..\..\libogg\include;%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>LIBVORBISFILE_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\..\vorbisfile.def</ModuleDefinitionFile>
+      <AdditionalDependencies>libogg.lib;libvorbis.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\$(Platform)\$(Configuration)\libvorbis.Windows;..\..\..\..\..\libogg\win32\VS2013\$(Platform)\$(Configuration)\libogg.Windows;</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -217,6 +221,8 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <DisableSpecificWarnings>4244;4305;4101;</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\..\..\..\libogg\include;%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>LIBVORBISFILE_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -224,6 +230,8 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\..\vorbisfile.def</ModuleDefinitionFile>
       <LinkTimeCodeGeneration />
+      <AdditionalDependencies>libogg.lib;libvorbis.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\$(Platform)\$(Configuration)\libvorbis.Windows;..\..\..\..\..\libogg\win32\VS2013\$(Platform)\$(Configuration)\libogg.Windows;</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2015/libvorbis-win10-universal.sln
+++ b/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2015/libvorbis-win10-universal.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libvorbis", "libvorbis-win10-universal\libvorbis-win10-universal.vcxproj", "{005F04F8-7C70-4340-9E2E-4B8966886D9D}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libvorbisfile", "libvorbisfile-win10-universal\libvorbisfile-win10-universal.vcxproj", "{9E831B2C-88DC-48BF-B2E0-67A15AF3384B}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libogg", "..\..\..\libogg\win32\VS2015\libogg-win10-universal\libogg-win10-universal.vcxproj", "{EFC56075-DE7F-4025-A94A-9EBF386D0112}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +43,18 @@ Global
 		{9E831B2C-88DC-48BF-B2E0-67A15AF3384B}.Release|x64.Build.0 = Release|x64
 		{9E831B2C-88DC-48BF-B2E0-67A15AF3384B}.Release|x86.ActiveCfg = Release|Win32
 		{9E831B2C-88DC-48BF-B2E0-67A15AF3384B}.Release|x86.Build.0 = Release|Win32
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Debug|ARM.ActiveCfg = Debug|ARM
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Debug|ARM.Build.0 = Debug|ARM
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Debug|x64.ActiveCfg = Debug|x64
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Debug|x64.Build.0 = Debug|x64
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Debug|x86.ActiveCfg = Debug|Win32
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Debug|x86.Build.0 = Debug|Win32
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Release|ARM.ActiveCfg = Release|ARM
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Release|ARM.Build.0 = Release|ARM
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Release|x64.ActiveCfg = Release|x64
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Release|x64.Build.0 = Release|x64
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Release|x86.ActiveCfg = Release|Win32
+		{EFC56075-DE7F-4025-A94A-9EBF386D0112}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2015/libvorbis-win10-universal/libvorbis-win10-universal.vcxproj
+++ b/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2015/libvorbis-win10-universal/libvorbis-win10-universal.vcxproj
@@ -96,6 +96,11 @@
   <ItemGroup>
     <None Include="..\..\vorbis.def" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\libogg\win32\VS2015\libogg-win10-universal\libogg-win10-universal.vcxproj">
+      <Project>{efc56075-de7f-4025-a94a-9ebf386d0112}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{005f04f8-7c70-4340-9e2e-4b8966886d9d}</ProjectGuid>
     <Keyword>DynamicLibrary</Keyword>
@@ -106,6 +111,8 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.10586.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -169,10 +176,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <GenerateManifest>false</GenerateManifest>
@@ -203,8 +212,9 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\vorbis.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -223,8 +233,9 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <LinkTimeCodeGeneration />
       <ModuleDefinitionFile>..\..\vorbis.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm'">
@@ -240,8 +251,9 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\vorbis.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Platform)\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm'">
@@ -260,8 +272,9 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <LinkTimeCodeGeneration />
       <ModuleDefinitionFile>..\..\vorbis.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Platform)\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -277,8 +290,9 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\vorbis.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Platform)\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -297,8 +311,9 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <LinkTimeCodeGeneration />
       <ModuleDefinitionFile>..\..\vorbis.def</ModuleDefinitionFile>
-      <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Platform)\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2015/libvorbisfile-win10-universal/libvorbisfile-win10-universal.vcxproj
+++ b/contrib/src/ogg/winrt/patch/libvorbis/win32/VS2015/libvorbisfile-win10-universal/libvorbisfile-win10-universal.vcxproj
@@ -36,6 +36,9 @@
     <ClInclude Include="..\..\..\include\vorbis\vorbisfile.h" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\libogg\win32\VS2015\libogg-win10-universal\libogg-win10-universal.vcxproj">
+      <Project>{efc56075-de7f-4025-a94a-9ebf386d0112}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\libvorbis-win10-universal\libvorbis-win10-universal.vcxproj">
       <Project>{005f04f8-7c70-4340-9e2e-4b8966886d9d}</Project>
     </ProjectReference>
@@ -50,6 +53,8 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -113,14 +118,18 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
+    <LinkIncremental />
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
+    <LinkIncremental />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <GenerateManifest>false</GenerateManifest>
@@ -129,6 +138,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
+    <LinkIncremental />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <GenerateManifest>false</GenerateManifest>
@@ -147,7 +157,7 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\vorbisfile.def</ModuleDefinitionFile>
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -167,7 +177,7 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\vorbisfile.def</ModuleDefinitionFile>
       <LinkTimeCodeGeneration />
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -184,7 +194,7 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\vorbisfile.def</ModuleDefinitionFile>
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Platform)\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -204,7 +214,7 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\vorbisfile.def</ModuleDefinitionFile>
       <LinkTimeCodeGeneration />
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\..\..\..\libogg\win32\VS2015\$(Platform)\$(Configuration)\libogg-win10-universal</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -221,7 +231,7 @@
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\vorbisfile.def</ModuleDefinitionFile>
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -240,7 +250,7 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>..\..\vorbisfile.def</ModuleDefinitionFile>
       <LinkTimeCodeGeneration />
-      <AdditionalDependencies>libogg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/contrib/src/openssl/winrt/build-win10.bat
+++ b/contrib/src/openssl/winrt/build-win10.bat
@@ -1,7 +1,10 @@
 @echo off
 
+Building OpenSSL for Windows 10.0...
+
 pushd temp
 	pushd openssl
+		echo creating Windows 10.0 Visual Studio projects...
 		call ms\do_vsprojects14.bat
 	popd
 
@@ -14,6 +17,8 @@ pushd temp
 	echo Building OpenSSL Windows 10.0 Release/ARM...
 	msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="ARM" /m
 
+	echo Building OpenSSL Windows 10.0 Release/x64...
+	msbuild %SOLUTION% /p:Configuration="Release" /p:Platform="x64" /m
 
 	pushd openssl
 		call ms\do_packwinuniversal.bat

--- a/contrib/src/openssl/winrt/build-win8.1.bat
+++ b/contrib/src/openssl/winrt/build-win8.1.bat
@@ -1,12 +1,15 @@
 @echo off
 
+Building OpenSSL for Windows 8.1...
+
 pushd temp
 
 	pushd openssl
+		echo creating Windows 8.1 Visual Studio projects...
 		call ms\do_vsprojects.bat
 	popd
 
-	call "%VS120COMNTOOLS%vsvars32.bat"
+	call "%VS140COMNTOOLS%vsvars32.bat"
 
 	set SOLUTION=openssl\vsout\NT-Phone-8.1-Dll-Unicode\NT-Phone-8.1-Dll-Unicode.vcxproj
 	echo Building OpenSSL Windows 8.1 Phone Release/Win32...
@@ -17,7 +20,7 @@ pushd temp
 
 	set SOLUTION=openssl\vsout\NT-Store-8.1-Dll-Unicode\NT-Store-8.1-Dll-Unicode.vcxproj
 	echo Building OpenSSL Windows 8.1 Store Release/Win32...
-	msbuild %SOLUTION% /p:Configuration="Release"  /p:Platform="Win32" /m
+	msbuild %SOLUTION% /p:Configuration="Release"  /p:Platform="x86" /m
 
 	echo Building OpenSSL Windows 8.1 Store Release/ARM...
 	msbuild %SOLUTION% /p:Configuration="Release"  /p:Platform="ARM" /m

--- a/contrib/src/openssl/winrt/clean.bat
+++ b/contrib/src/openssl/winrt/clean.bat
@@ -1,0 +1,10 @@
+@echo off
+
+if exist temp (
+	rm -rf temp
+)
+
+if exist install (
+	rm -rf install
+)
+

--- a/contrib/src/openssl/winrt/dobuild.bat
+++ b/contrib/src/openssl/winrt/dobuild.bat
@@ -1,0 +1,6 @@
+@echo off
+
+start /wait cmd /c "clean.bat"
+start /wait cmd /c "download.bat"
+start /wait cmd /c "build-win8.1.bat"
+start /wait cmd /c "build-win10.bat"

--- a/contrib/src/openssl/winrt/download.bat
+++ b/contrib/src/openssl/winrt/download.bat
@@ -1,7 +1,9 @@
 @echo off
 
-set SHA=b4da0d80af262ff0aa431fef88fc0c1ca76abac9
-set URL=https://github.com/Microsoft/openssl/archive/%SHA%.tar.gz
+set branch=remotes/origin/OpenSSL_1_0_2_WinRT-stable
+set URL=https://github.com/Microsoft/openssl.git
+
+echo Cloning OpenSSL source code from %URL%...
 
 if exist temp (
 	rm -rf temp
@@ -15,13 +17,10 @@ mkdir temp
 mkdir install
 
 pushd temp
-	if not exist %SHA%.tar.gz (
-		curl -O -L %URL%
-	)
-	
-	echo Decompressing source code...
-	tar -xzf %SHA%.tar.gz
-	mv openssl-%SHA% openssl
+	git clone %URL%
+	cd openssl
+	echo Checking out git branch %BRANCH%...
+	git checkout %BRANCH%
 popd
 
 echo Download complete.

--- a/contrib/src/png/winrt/README.txt
+++ b/contrib/src/png/winrt/README.txt
@@ -1,0 +1,1 @@
+There is no need to build png for the winrt platforms (Win10 UWP and Windows 8.1 Universal). The winrt platforms use WIC to load png files.

--- a/contrib/src/sqlite/winrt/build.bat
+++ b/contrib/src/sqlite/winrt/build.bat
@@ -1,8 +1,10 @@
 @echo off
 
-set VERSION=3081002
-set PHONE_URL=https://www.sqlite.org/2015/sqlite-wp81-winrt-%VERSION%.vsix
-set WINRT_URL=https://www.sqlite.org/2015/sqlite-winrt81-%VERSION%.vsix
+set VERSION=3120100
+set PHONE_URL=https://www.sqlite.org/2016/sqlite-wp81-winrt-%VERSION%.vsix
+set WINRT_URL=https://www.sqlite.org/2016/sqlite-winrt81-%VERSION%.vsix
+set WIN10_URL=https://www.sqlite.org/2016/sqlite-uwp-%VERSION%.vsix
+
 
 if exist temp (
 	rm -rf temp
@@ -23,9 +25,14 @@ pushd temp
 	if not exist sqlite-wp81-winrt-%VERSION%.vsix (
 		curl -O -L %PHONE_URL%
 	)
+	
+	if not exist sqlite-uwp-%VERSION%.vsix (
+		curl -O -L %WIN10_URL%
+	)
 
 	unzip sqlite-winrt81-%VERSION%.vsix -d winrt_8.1
 	unzip sqlite-wp81-winrt-%VERSION%.vsix	-d wp_8.1
+	unzip sqlite-uwp-%VERSION%.vsix	-d win10
 popd
 
 echo Installing sqlite...
@@ -47,6 +54,16 @@ xcopy "%INDIR%\DesignTime\Retail\x86\sqlite3.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\Redist\Retail\x86\sqlite3.dll" "%OUTDIR%\*" /iycq
 
 set OUTDIR=install\sqlite3\libraries\winrt_8.1\arm
+xcopy "%INDIR%\DesignTime\Retail\ARM\sqlite3.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\Redist\Retail\ARM\sqlite3.dll" "%OUTDIR%\*" /iycq
+
+set INDIR=temp\win10\
+
+set OUTDIR=install\sqlite3\libraries\win10\win32
+xcopy "%INDIR%\DesignTime\Retail\x86\sqlite3.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\Redist\Retail\x86\sqlite3.dll" "%OUTDIR%\*" /iycq
+
+set OUTDIR=install\sqlite3\libraries\win10\arm
 xcopy "%INDIR%\DesignTime\Retail\ARM\sqlite3.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\Redist\Retail\ARM\sqlite3.dll" "%OUTDIR%\*" /iycq
 

--- a/contrib/src/tiff/winrt/README.txt
+++ b/contrib/src/tiff/winrt/README.txt
@@ -1,0 +1,1 @@
+There is no need to build tiff for the winrt platforms (Win10 UWP and Windows 8.1 Universal). The winrt platforms use WIC to load tiff files.

--- a/contrib/src/zlib/winrt/build.bat
+++ b/contrib/src/zlib/winrt/build.bat
@@ -18,10 +18,12 @@ mkdir install
 pushd temp
 
 	if not exist zlib-%VERSION%.tar.gz (
+		echo Downloading zlib-%VERSION%.tar.gz...
 		curl -O -L %URL%
 	)
 
-	tar -xzvf zlib-%VERSION%.tar.gz
+	echo Decompressing zlib-%VERSION%.tar.gz...
+	tar -xzf zlib-%VERSION%.tar.gz
 
 	pushd zlib-%VERSION%
 		set SRC=%cd%
@@ -34,12 +36,12 @@ pushd temp
 		mkdir win32
 		pushd win32
 			set INSTALL=%CD%\install
-			cmake -G"Visual Studio 12 2013" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
+			cmake -G"Visual Studio 14 2015" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
 		popd
 		mkdir arm
 		pushd arm
 			set INSTALL=%CD%\install
-			cmake -G"Visual Studio 12 2013 ARM" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
+			cmake -G"Visual Studio 14 2015 ARM" -DCMAKE_SYSTEM_NAME=WindowsPhone -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
 		popd
 	popd
 	
@@ -48,58 +50,114 @@ pushd temp
 		mkdir win32
 		pushd win32
 			set INSTALL=%CD%\install
-			cmake -G"Visual Studio 12 2013" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
+			cmake -G"Visual Studio 14 2015" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
 		popd
 		mkdir arm
 		pushd arm
 			set INSTALL=%CD%\install
-			cmake -G"Visual Studio 12 2013 ARM" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
+			cmake -G"Visual Studio 14 2015 ARM" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
 		popd
 	popd
 	
-	call "%VS120COMNTOOLS%vsvars32.bat"
+	mkdir win10
+	pushd win10 
+		mkdir win32
+		pushd win32
+			set INSTALL=%CD%\install
+			cmake -G"Visual Studio 14 2015" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
+		popd
+		rem mkdir x64
+		rem pushd x64
+			rem set INSTALL=%CD%\install
+			rem cmake -G"Visual Studio 14 2015 Win64" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0  -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
+		rem popd
+		mkdir arm
+		pushd arm
+			set INSTALL=%CD%\install
+			cmake -G"Visual Studio 14 2015 ARM" -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_INSTALL_PREFIX:PATH=%INSTALL% %CMAKE_ARGS% %SRC%
+		popd
+	popd
+	
+	call "%VS140COMNTOOLS%vsvars32.bat"
 
 	echo Building zlib Windows 8.1 Phone Release/Win32...
-	msbuild wp_8.1\win32\zlib.sln /p:Configuration="Release" /p:Platform="Win32" /m
-	msbuild wp_8.1\win32\INSTALL.vcxproj /p:Configuration="Release" /p:Platform="Win32" /m
+	msbuild wp_8.1\win32\zlib.sln /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+	msbuild wp_8.1\win32\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
 	
 	echo Building zlib Windows 8.1 Phone Release/ARM...
-	msbuild wp_8.1\arm\zlib.sln /p:Configuration="Release" /p:Platform="ARM" /m
-	msbuild wp_8.1\arm\INSTALL.vcxproj /p:Configuration="Release" /p:Platform="ARM" /m
+	msbuild wp_8.1\arm\zlib.sln /p:Configuration="MinSizeRel" /p:Platform="ARM" /m
+	msbuild wp_8.1\arm\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="ARM" /m
 
 	echo Building zlib Windows 8.1 Store Release/Win32...
-	msbuild ws_8.1\win32\zlib.sln /p:Configuration="Release" /p:Platform="Win32" /m
-	msbuild ws_8.1\win32\INSTALL.vcxproj /p:Configuration="Release" /p:Platform="Win32" /m
+	msbuild ws_8.1\win32\zlib.sln /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+	msbuild ws_8.1\win32\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
 
 	echo Building zlib Windows 8.1 Store Release/ARM...
-	msbuild ws_8.1\arm\zlib.sln /p:Configuration="Release" /p:Platform="ARM" /m
-	msbuild ws_8.1\arm\INSTALL.vcxproj /p:Configuration="Release" /p:Platform="ARM" /m
+	msbuild ws_8.1\arm\zlib.sln /p:Configuration="MinSizeRel" /p:Platform="ARM" /m
+	msbuild ws_8.1\arm\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="ARM" /m
+	
+	echo Building zlib Windows 10.0 Release/Win32...
+	msbuild win10\win32\zlib.sln /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+	msbuild win10\win32\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="Win32" /m
+
+	rem echo Building zlib Windows 10.0 Release/x64...
+	rem msbuild win10\x64\zlib.sln /p:Configuration="MinSizeRel" /p:Platform="x64" /m
+	rem msbuild win10\x64\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="x64" /m
+
+	echo Building zlib Windows 10.0 Release/ARM...
+	msbuild win10\arm\zlib.sln /p:Configuration="MinSizeRel" /p:Platform="ARM" /m
+	msbuild win10\arm\INSTALL.vcxproj /p:Configuration="MinSizeRel" /p:Platform="ARM" /m
 popd
+
 
 echo Installing zlib...
 
 set INDIR=temp\wp_8.1\win32\install
-set OUTDIR=install\zlib\prebuilt\wp_8.1\win32
+set OUTDIR=install\wp_8.1-specific\zlib\prebuilt\win32
 xcopy "%INDIR%\include" "install\wp_8.1-specific\zlib\include\" /iycqs
+xcopy "%INDIR%\lib\zlibstatic.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\lib\zlib.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\bin\zlib.dll" "%OUTDIR%\*" /iycq
 
 set INDIR=temp\wp_8.1\arm\install
-set OUTDIR=install\zlib\prebuilt\wp_8.1\arm
+set OUTDIR=install\wp_8.1-specific\zlib\prebuilt\arm
+xcopy "%INDIR%\lib\zlibstatic.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\lib\zlib.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\bin\zlib.dll" "%OUTDIR%\*" /iycq
 
 set INDIR=temp\ws_8.1\win32\install
-set OUTDIR=install\zlib\prebuilt\winrt_8.1\win32
+set OUTDIR=install\winrt_8.1-specific\zlib\prebuilt\win32
 xcopy "%INDIR%\include" "install\winrt_8.1-specific\zlib\include\" /iycqs
+xcopy "%INDIR%\lib\zlibstatic.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\lib\zlib.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\bin\zlib.dll" "%OUTDIR%\*" /iycq
 
 set INDIR=temp\ws_8.1\arm\install
-set OUTDIR=install\zlib\prebuilt\winrt_8.1\arm
+set OUTDIR=install\winrt_8.1-specific\zlib\prebuilt\arm
+xcopy "%INDIR%\lib\zlibstatic.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\lib\zlib.lib" "%OUTDIR%\*" /iycq
 xcopy "%INDIR%\bin\zlib.dll" "%OUTDIR%\*" /iycq
-	
+
+set INDIR=temp\win10\win32\install
+set OUTDIR=install\win10-specific\zlib\prebuilt\win32
+xcopy "%INDIR%\include" "install\win10-specific\zlib\include\" /iycqs
+xcopy "%INDIR%\lib\zlibstatic.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\lib\zlib.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\bin\zlib.dll" "%OUTDIR%\*" /iycq
+
+rem set INDIR=temp\win10\x64\install
+rem set OUTDIR=install\win10-specific\zlib\prebuilt\x64
+rem xcopy "%INDIR%\lib\zlibstatic.lib" "%OUTDIR%\*" /iycq
+rem xcopy "%INDIR%\lib\zlib.lib" "%OUTDIR%\*" /iycq
+rem xcopy "%INDIR%\bin\zlib.dll" "%OUTDIR%\*" /iycq
+
+set INDIR=temp\win10\arm\install
+set OUTDIR=install\win10-specific\zlib\prebuilt\arm
+xcopy "%INDIR%\lib\zlibstatic.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\lib\zlib.lib" "%OUTDIR%\*" /iycq
+xcopy "%INDIR%\bin\zlib.dll" "%OUTDIR%\*" /iycq
+
+
 echo zlib build complete.
 
 

--- a/contrib/src/zlib/winrt/download.bat
+++ b/contrib/src/zlib/winrt/download.bat
@@ -1,0 +1,34 @@
+@echo off
+
+echo Downloading zlib...
+
+
+set VERSION="1.2.8"
+set URL=http://downloads.sourceforge.net/project/libpng/zlib/%VERSION%/zlib-%VERSION%.tar.gz
+
+if exist temp (
+	rm -rf temp
+)
+
+if exist install (
+	rm -rf install
+)
+
+mkdir temp
+mkdir install
+
+pushd temp
+	if not exist zlib-%VERSION%.tar.gz (
+		curl -O -L %URL%
+	)
+
+	echo Decompressing zlib...
+	tar -xzf zlib-%VERSION%.tar.gz
+	mv zlib-%VERSION% zlib
+popd
+
+echo Download complete.
+
+
+
+


### PR DESCRIPTION
This pull request updates all of the winrt build scripts to build both the Win10 UWP and Windows 8.1 3rd party libs. Visual Studio 2015 Update 1 is required to build all of the libs.

The following winrt build scripts are now available

curl updated to v.7.48
openssl 
angle updated to v2.1.7
zlib
freetype
chipmunk fixed CP_EXPORT define for winrt
websockets
ogg
sqlite updated to version 3120100

@ricardoquesada FYI
