### PR TITLE
add "-mtvos-version-min" configuration to build libraries for tvOS

### DIFF
--- a/contrib/bootstrap
+++ b/contrib/bootstrap
@@ -171,8 +171,8 @@ check_tvos_sdk()
    else
        EX_CFLAGS="-isysroot ${SDKROOT} -arch ${MY_TARGET_ARCH}"
    fi
-   add_make "EXTRA_CFLAGS := ${EX_CFLAGS}"
-   add_make "EXTRA_LDFLAGS := -L${SDKROOT}/usr/lib -arch ${MY_TARGET_ARCH} -isysroot ${SDKROOT}"
+   add_make "EXTRA_CFLAGS := ${EX_CFLAGS} -mtvos-version-min=9.0"
+   add_make "EXTRA_LDFLAGS := -L${SDKROOT}/usr/lib -arch ${MY_TARGET_ARCH} -isysroot ${SDKROOT} -mtvos-version-min=9.0"
 }
 
 check_ios_sdk()

--- a/contrib/src/openssl/rules.mak
+++ b/contrib/src/openssl/rules.mak
@@ -83,7 +83,7 @@ ifdef HAVE_IOS
 	cd $< && perl -i -pe "s|^CFLAG= (.*)|CFLAG= -isysroot ${IOS_SDK} ${OPTIM} ${ENABLE_BITCODE} |g" Makefile
 endif
 ifdef HAVE_TVOS
-	cd $< && perl -i -pe "s|^CC= xcrun clang|CC= xcrun cc -arch ${MY_TARGET_ARCH} |g" Makefile
+	cd $< && perl -i -pe "s|^CC= xcrun clang|CC= xcrun cc -arch ${MY_TARGET_ARCH} -mtvos-version-min=9.0 |g" Makefile
 	cd $< && perl -i -pe "s|^CFLAG= (.*)|CFLAG= -DHAVE_FORK=0 -isysroot ${TVOS_SDK} ${OPTIM} ${ENABLE_BITCODE} |g" Makefile
 endif
 ifdef HAVE_LINUX


### PR DESCRIPTION
The libraries will be required to build with "mtvos-version-min" in order to link the libraries to tvOS app which specifies older deployment target (ie. tvos 9.0)
