### PR TITLE
[iOS] Enables ASM for armv7 arch again. Need to apply a patch from openssl official.

### DIFF
--- a/contrib/src/openssl/ios-armv7-crash.patch
+++ b/contrib/src/openssl/ios-armv7-crash.patch
@@ -1,0 +1,115 @@
+From aba772c5299d11f898465bf3e6a9c6e7b52b9893 Mon Sep 17 00:00:00 2001
+From: Andy Polyakov <appro@openssl.org>
+Date: Mon, 13 Feb 2017 18:16:16 +0100
+Subject: [PATCH] ARMv4 assembly pack: harmonize Thumb-ification of iOS build.
+
+Three modules were left behind in a285992763f3961f69a8d86bf7dfff020a08cef9.
+
+Reviewed-by: Rich Salz <rsalz@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/2617)
+---
+ crypto/aes/asm/aesv8-armx.pl     | 9 ++++++---
+ crypto/armv4cpuid.pl             | 1 +
+ crypto/modes/asm/ghashv8-armx.pl | 6 +++++-
+ 3 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/crypto/aes/asm/aesv8-armx.pl b/crypto/aes/asm/aesv8-armx.pl
+index 9246dbb43..1782d5b41 100755
+--- a/crypto/aes/asm/aesv8-armx.pl
++++ b/crypto/aes/asm/aesv8-armx.pl
+@@ -59,9 +59,12 @@ $code=<<___;
+ .text
+ ___
+ $code.=".arch	armv8-a+crypto\n"			if ($flavour =~ /64/);
+-$code.=".arch	armv7-a\n.fpu	neon\n.code	32\n"	if ($flavour !~ /64/);
+-		#^^^^^^ this is done to simplify adoption by not depending
+-		#	on latest binutils.
++$code.=<<___						if ($flavour !~ /64/);
++.arch	armv7-a	// don't confuse not-so-latest binutils with argv8 :-)
++.fpu	neon
++.code	32
++#undef	__thumb2__
++___
+ 
+ # Assembler mnemonics are an eclectic mix of 32- and 64-bit syntax,
+ # NEON is mostly 32-bit mnemonics, integer - mostly 64. Goal is to
+diff --git a/crypto/armv4cpuid.pl b/crypto/armv4cpuid.pl
+index 33c893d0e..f7d31a698 100644
+--- a/crypto/armv4cpuid.pl
++++ b/crypto/armv4cpuid.pl
+@@ -27,6 +27,7 @@ $code.=<<___;
+ .thumb
+ #else
+ .code	32
++#undef	__thumb2__
+ #endif
+ 
+ .align	5
+diff --git a/crypto/modes/asm/ghashv8-armx.pl b/crypto/modes/asm/ghashv8-armx.pl
+index cb4537b22..dcd5f595d 100644
+--- a/crypto/modes/asm/ghashv8-armx.pl
++++ b/crypto/modes/asm/ghashv8-armx.pl
+@@ -67,7 +67,11 @@ $code=<<___;
+ .text
+ ___
+ $code.=".arch	armv8-a+crypto\n"	if ($flavour =~ /64/);
+-$code.=".fpu	neon\n.code	32\n"	if ($flavour !~ /64/);
++$code.=<<___				if ($flavour !~ /64/);
++.fpu	neon
++.code	32
++#undef	__thumb2__
++___
+ 
+ ################################################################################
+ # void gcm_init_v8(u128 Htable[16],const u64 H[2]);
+-- 
+2.11.0
+
+From 2270f45b811226cd3d91ac657ab7ab3d84726de0 Mon Sep 17 00:00:00 2001
+From: Andy Polyakov <appro@openssl.org>
+Date: Wed, 15 Feb 2017 12:01:09 +0100
+Subject: [PATCH] crypto/armcap.c: short-circuit processor capability probe in
+ iOS builds.
+
+Capability probing by catching SIGILL appears to be problematic
+on iOS. But since Apple universe is "monocultural", it's actually
+possible to simply set pre-defined processor capability mask.
+
+Reviewed-by: Rich Salz <rsalz@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/2617)
+---
+ crypto/armcap.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/crypto/armcap.c b/crypto/armcap.c
+index 4215766bf..29534845d 100644
+--- a/crypto/armcap.c
++++ b/crypto/armcap.c
+@@ -111,6 +111,24 @@ void OPENSSL_cpuid_setup(void)
+         return;
+     }
+ 
++# if defined(__APPLE__) && !defined(__aarch64__)
++    /*
++     * Capability probing by catching SIGILL appears to be problematic
++     * on iOS. But since Apple universe is "monocultural", it's actually
++     * possible to simply set pre-defined processor capability mask.
++     */
++    if (1) {
++        OPENSSL_armcap_P = ARMV7_NEON;
++        return;
++    }
++    /*
++     * One could do same even for __aarch64__ iOS builds. It's not done
++     * exclusively for reasons of keeping code unified across platforms.
++     * Unified code works because it never triggers SIGILL on Apple
++     * devices...
++     */
++# endif
++
+     sigfillset(&all_masked);
+     sigdelset(&all_masked, SIGILL);
+     sigdelset(&all_masked, SIGTRAP);
+-- 
+2.11.0
+

--- a/contrib/src/openssl/rules.mak
+++ b/contrib/src/openssl/rules.mak
@@ -69,8 +69,7 @@ ifdef HAVE_IOS
 ifeq ($(MY_TARGET_ARCH),armv7)
 IOS_PLATFORM=OS
 OPENSSL_CONFIG_VARS=ios-cross
-# Adds no-asm option to avoid crash at startup on armv7/armv7s iOS devices.
-OPENSSL_EXTRA_CONFIG_2=no-asm no-async
+OPENSSL_EXTRA_CONFIG_2=no-async
 endif
 
 ifeq ($(MY_TARGET_ARCH),arm64)
@@ -81,7 +80,7 @@ endif
 ifeq ($(MY_TARGET_ARCH),armv7s)
 IOS_PLATFORM=OS
 OPENSSL_CONFIG_VARS=ios-cross
-OPENSSL_EXTRA_CONFIG_2=no-asm no-async
+OPENSSL_EXTRA_CONFIG_2=no-async
 endif
 
 ifeq ($(MY_TARGET_ARCH),i386)
@@ -123,6 +122,9 @@ $(TARBALLS)/openssl-$(OPENSSL_VERSION).tar.gz:
 
 openssl: openssl-$(OPENSSL_VERSION).tar.gz .sum-openssl
 	$(UNPACK)
+ifdef HAVE_IOS
+	$(APPLY) $(SRC)/openssl/ios-armv7-crash.patch
+endif
 	$(MOVE)
 
 .openssl: openssl


### PR DESCRIPTION
Please refer to https://github.com/openssl/openssl/pull/2617