### PR TITLE
Fix download URL of zlib

### DIFF
--- a/contrib/src/zlib/rules.mak
+++ b/contrib/src/zlib/rules.mak
@@ -1,6 +1,6 @@
 # ZLIB
 ZLIB_VERSION := 1.2.8
-ZLIB_URL := http://zlib.net/zlib-$(ZLIB_VERSION).tar.gz
+ZLIB_URL := http://zlib.net/fossils/zlib-$(ZLIB_VERSION).tar.gz
 
 
 ifeq ($(shell uname),Darwin) # zlib tries to use libtool on Darwin


### PR DESCRIPTION
Download URL of zlib seems to be modified.

Building some libraries is failure because of not found.