### PR TITLE
Fix OpenSSL compilation for tvOS. Fix PNG URL.

### DIFF
--- a/contrib/src/main.mak
+++ b/contrib/src/main.mak
@@ -22,7 +22,7 @@ VPATH := $(TARBALLS)
 
 # Common download locations
 GNU := http://ftp.gnu.org/gnu
-SF := http://heanet.dl.sourceforge.net/sourceforge
+SF := https://downloads.sourceforge.net/project
 GITHUB := https://github.com
 
 

--- a/contrib/src/png/rules.mak
+++ b/contrib/src/png/rules.mak
@@ -1,6 +1,6 @@
 # PNG
 PNG_VERSION := 1.6.16
-PNG_URL := $(SF)/libpng/libpng16/$(PNG_VERSION)/libpng-$(PNG_VERSION).tar.xz
+PNG_URL := $(SF)/libpng/libpng16/older-releases/$(PNG_VERSION)/libpng-$(PNG_VERSION).tar.xz
 
 
 $(TARBALLS)/libpng-$(PNG_VERSION).tar.xz:


### PR DESCRIPTION
This PR fixes the compilation of OpenSSL for tvOS.
It also fixes the PNG source download URL from SourceForge.