### PR TITLE
fix compile error on mac

### DIFF
--- a/contrib/src/main.mak
+++ b/contrib/src/main.mak
@@ -416,8 +416,8 @@ ifdef HAVE_WIN32
 endif
 ifdef HAVE_DARWIN_OS
 	echo "set(CMAKE_SYSTEM_NAME Darwin)" >> $@
-	echo "set(CMAKE_C_FLAGS $(CFLAGS))" >> $@
-	echo "set(CMAKE_CXX_FLAGS $(CFLAGS))" >> $@
+	echo "set(CMAKE_C_FLAGS \"$(CFLAGS)\")" >> $@
+	echo "set(CMAKE_CXX_FLAGS \"$(CFLAGS)\")" >> $@
 	echo "set(CMAKE_LD_FLAGS $(LDFLAGS))" >> $@
 	echo "set(CMAKE_AR ar CACHE FILEPATH "Archiver")" >> $@
 ifdef HAVE_TVOS


### PR DESCRIPTION
generated `toolchain.cmake` missing quotation marks