### PR TITLE
v2: mod archive file download URL

### DIFF
--- a/contrib/src/main.mak
+++ b/contrib/src/main.mak
@@ -22,7 +22,7 @@ VPATH := $(TARBALLS)
 
 # Common download locations
 GNU := http://ftp.gnu.org/gnu
-SF := http://heanet.dl.sourceforge.net/sourceforge
+SF := http://downloads.sourceforge.net/sourceforge
 
 #
 # Machine-dependent variables

--- a/contrib/src/tiff/rules.mak
+++ b/contrib/src/tiff/rules.mak
@@ -1,7 +1,7 @@
 # tiff
 
 TIFF_VERSION := 4.0.3
-TIFF_URL := http://download.osgeo.org/libtiff/tiff-$(TIFF_VERSION).tar.gz
+TIFF_URL := http://download.osgeo.org/libtiff/old/tiff-$(TIFF_VERSION).tar.gz
 
 $(TARBALLS)/tiff-$(TIFF_VERSION).tar.gz:
 	$(call download,$(TIFF_URL))


### PR DESCRIPTION
NG: http://heanet.dl.sourceforge.net/sourceforge/libpng/libpng16/1.6.16/libpng-1.6.16.tar.xz
OK: http://downloads.sourceforge.net/sourceforge/libpng/libpng16/1.6.16/libpng-1.6.16.tar.xz

ex. 
```
./build.sh -p=android --libs=png --arch=arm64 --mode=release

build api is 21.
checking arm64 is in arm armv7 x86 arm64 mips
checking png is in png zlib lua luajit websockets curl freetype jpeg tiff webp chipmunk openssl rapidjson

build arm64 for png in android
toolchain path is /???/android-ndk-r10e/toolchains/aarch64-linux-android-4.9/prebuilt/darwin-x86_64/bin
Creating configuration file... config.mak
The host is linux-android
check android sdk
we are using mthumb for arm64-v8a!!
Bootstrap completed.

Run "make" to start compilation.

Other targets:
 * make install      same as "make"
 * make list         list packages
 * make fetch        fetch required source tarballs
 * make fetch-all    fetch all source tarballs
 * make distclean    clean everything and undo bootstrap
 * make mostlyclean  clean everything except source tarballs
 * make clean        clean everything
curl -f -L -- "http://heanet.dl.sourceforge.net/sourceforge/libpng/libpng16/1.6.16/libpng-1.6.16.tar.xz" > "../../contrib/tarballs/libpng-1.6.16.tar.xz"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: heanet.dl.sourceforge.net
make: *** [../../contrib/tarballs/libpng-1.6.16.tar.xz] Error 6
make: *** Deleting file `../../contrib/tarballs/libpng-1.6.16.tar.xz'
```