### PR TITLE
Fix problems with rapidjson

### DIFF
--- a/contrib/src/rapidjson/rules.mak
+++ b/contrib/src/rapidjson/rules.mak
@@ -1,6 +1,6 @@
 # rapidjson
 
-RAPIDJSON_GITURL := https://github.com/miloyip/rapidjson
+RAPIDJSON_GITURL := https://github.com/Tencent/rapidjson 
 
 
 $(TARBALLS)/librapidjson-git.tar.xz:

--- a/contrib/src/rapidjson/rules.mak
+++ b/contrib/src/rapidjson/rules.mak
@@ -4,7 +4,7 @@ RAPIDJSON_GITURL := https://github.com/miloyip/rapidjson
 
 
 $(TARBALLS)/librapidjson-git.tar.xz:
-	$(call download_git,$(RAPIDJSON_GITURL),master,3d5848a)
+	$(call download_git,$(RAPIDJSON_GITURL),master,f54b0e47)
 
 .sum-rapidjson: librapidjson-git.tar.xz
 	$(warning $@ not implemented)


### PR DESCRIPTION
There is an incorrect commit-hash in rules.mak for rapidjson 1.1.0 (it's in-existent)
I looked into sources of cocos2d-x externals binaries and took version stored in rapidjson.h file, then found a specific tag inside rapidjson repo (v1.1.0)
Another change reflects rapidjson git repo has changed URL