### PR TITLE
Support android x86_64 arch

### DIFF
--- a/build/android.ini
+++ b/build/android.ini
@@ -6,10 +6,12 @@ cfg_default_build_libraries="all"
 #specific default values
 cfg_default_build_api=14
 cfg_default_arm64_build_api=21
+cfg_default_x86_64_build_api=21
 cfg_arm_alias_folder_name="armeabi"
 cfg_armv7_alias_folder_name="armeabi-v7a"
 cfg_arm64_alias_folder_name="arm64-v8a"
 cfg_mips_alias_folder_name="mips"
+cfg_x86_64_alias_folder_name="x86_64"
 cfg_default_build_stl="clang"  #clang is another option
 
 #build machine & build host
@@ -19,15 +21,16 @@ cfg_arm64_host_machine="aarch64-linux-android"
 cfg_arm_host_machine="arm-linux-androideabi"
 cfg_armv7_host_machine="arm-linux-androideabi"
 cfg_mips_host_machine="mipsel-linux-android"
+cfg_x86_64_host_machine="x86_64-linux-android"
 
 #only cross compile should define thse variables
 cfg_is_cross_compile=yes
 
 
 #build arches and build libraries
-cfg_all_supported_arches=("armv7" "x86" "arm64" "mips")
+cfg_all_supported_arches=("armv7" "x86" "x86_64" "arm64" "mips")
 cfg_all_supported_libraries=("png" "zlib" "luajit" "websockets" "curl" "freetype" "jpeg"  "tiff" "webp" "chipmunk" "openssl" "bullet" "box2d" "uv" "glsl_optimizer")
-cfg_default_arches_all=("armv7" "x86" "arm64")
+cfg_default_arches_all=("armv7" "x86" "x86_64" "arm64")
 cfg_default_libraries_all=("png" "zlib" "luajit" "websockets" "curl" "freetype" "jpeg" "tiff" "webp" "chipmunk" "openssl" "bullet" "box2d" "uv" "glsl_optimizer")
 
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -377,6 +377,8 @@ do
         if [ $cfg_platform_name = "android" ];then
             if [ $MY_TARGET_ARCH = "arm64-v8a" ];then
                 export ANDROID_API=android-$cfg_default_arm64_build_api
+            elif [ $MY_TARGET_ARCH = "x86_64" ];then
+                export ANDROID_API=android-$cfg_default_x86_64_build_api
             else
                 export ANDROID_API=android-$build_api
             fi


### PR DESCRIPTION
Draft support of x86_64 arch for Android.
Spidermonkey has to be built separately as it's not included in this repo.
Probably should build on latest branch v33 https://github.com/ricardoquesada/Spidermonkey/tree/v33